### PR TITLE
🤝 Allow maintainers to update Secrets Manager values

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,7 +24,7 @@ updates:
       prefix: ":dependabot: pip"
       include: "scope"
   - package-ecosystem: "terraform"
-    directory: "/"
+    directory: "terraform"
     schedule:
       interval: "daily"
     commit-message:

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -24,8 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # environment: [development, test, production]
-        environment: [development]
+        environment: [development, test, production]
     defaults:
       run:
         working-directory: terraform
@@ -68,7 +67,7 @@ jobs:
           terraform plan -out=${{ matrix.environment }}.tfplan -input=false
 
       - name: Terraform Apply
-        # if: github.ref == 'refs/heads/main'
+        if: github.ref == 'refs/heads/main'
         id: terraform_apply
         shell: bash
         run: |

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -24,7 +24,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        environment: [development, test, production]
+        # environment: [development, test, production]
+        environment: [development]
     defaults:
       run:
         working-directory: terraform
@@ -67,7 +68,7 @@ jobs:
           terraform plan -out=${{ matrix.environment }}.tfplan -input=false
 
       - name: Terraform Apply
-        if: github.ref == 'refs/heads/main'
+        # if: github.ref == 'refs/heads/main'
         id: terraform_apply
         shell: bash
         run: |

--- a/environments/development/analytical-platform/example-external-role/workflow.yml
+++ b/environments/development/analytical-platform/example-external-role/workflow.yml
@@ -10,3 +10,7 @@ dag:
 
 iam:
   external_role: arn:aws:iam::123456789012:role/this-is-not-a-real-role
+
+maintainers:
+  - jacobwoffenden
+  - julialawrence

--- a/environments/development/analytical-platform/example-multi-task/workflow.yml
+++ b/environments/development/analytical-platform/example-multi-task/workflow.yml
@@ -26,3 +26,7 @@ dag:
 
 iam:
   bedrock: false
+
+maintainers:
+  - jacobwoffenden
+  - julialawrence

--- a/environments/development/analytical-platform/example/workflow.yml
+++ b/environments/development/analytical-platform/example/workflow.yml
@@ -19,6 +19,10 @@ iam:
     - mojap-compute-development-dummy/readwrite1/*
     - mojap-compute-development-dummy/readwrite2/*
 
+maintainers:
+  - jacobwoffenden
+  - julialawrence
+
 secrets:
   - username
   - password

--- a/environments/production/analytical-platform/example-multi-task/workflow.yml
+++ b/environments/production/analytical-platform/example-multi-task/workflow.yml
@@ -23,3 +23,7 @@ dag:
         PHASE: "three"
       compute_profile: gpu-spot-1vcpu-4gb
       dependencies: [phase-one, phase-two]
+
+maintainers:
+  - jacobwoffenden
+  - julialawrence

--- a/environments/production/analytical-platform/example/workflow.yml
+++ b/environments/production/analytical-platform/example/workflow.yml
@@ -6,3 +6,7 @@ tags:
 dag:
   repository: ministryofjustice/analytical-platform-airflow-poc-workflow
   tag: 0.0.6
+
+maintainers:
+  - jacobwoffenden
+  - julialawrence

--- a/environments/test/analytical-platform/example-multi-task/workflow.yml
+++ b/environments/test/analytical-platform/example-multi-task/workflow.yml
@@ -23,3 +23,7 @@ dag:
         PHASE: "three"
       compute_profile: gpu-spot-1vcpu-4gb
       dependencies: [phase-one, phase-two]
+
+maintainers:
+  - jacobwoffenden
+  - julialawrence

--- a/environments/test/analytical-platform/example/workflow.yml
+++ b/environments/test/analytical-platform/example/workflow.yml
@@ -6,3 +6,7 @@ tags:
 dag:
   repository: ministryofjustice/analytical-platform-airflow-poc-workflow
   tag: 0.0.6
+
+maintainers:
+  - jacobwoffenden
+  - julialawrence

--- a/scripts/workflow_schema_validation/schema.json
+++ b/scripts/workflow_schema_validation/schema.json
@@ -144,5 +144,13 @@
       "regex": "^[a-z-]+$"
     },
     "required": false
+  },
+  "maintainers": {
+    "type": "list",
+    "schema": {
+      "type": "string",
+      "regex": "^[a-z-]+$"
+    },
+    "required": true
   }
 }

--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -1,0 +1,65 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.84.0"
+  constraints = ">= 4.0.0, >= 5.0.0, ~> 5.0, 5.84.0"
+  hashes = [
+    "h1:MVppdPvKcROdwwj1i7OMoZ/ODFZlqrYr7GVHI1Fevb8=",
+    "zh:078f77438aba6ec8bf9154b7d223e5c71c48d805d6cd3bcf9db0cc1e82668ac3",
+    "zh:1f6591ff96be00501e71b792ed3a5a14b21ff03afec9a1c4a3fd9300e6e5b674",
+    "zh:2ab694e022e81dd74485351c5836148a842ed71cf640664c9d871cb517b09602",
+    "zh:33c8ccb6e3dc496e828a7572dd981366c6271075c1189f249b9b5236361d7eff",
+    "zh:6f31068ebad1d627e421c72ccdaafe678c53600ca73714e977bf45ff43ae5d17",
+    "zh:7488623dccfb639347cae66f9001d39cf06b92e8081975235a1ac3a0ac3f44aa",
+    "zh:7f042b78b9690a8725c95b91a70fc8e264011b836605bcc342ac297b9ea3937d",
+    "zh:88b56ac6c7209dc0a775b79975a371918f3aed8f015c37d5899f31deff37c61a",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a1979ba840d704af0932f8de5f541cbb4caa9b6bbd25ed552a24e6772175ba07",
+    "zh:b058c0533dae580e69d1adbc1f69e6a80632374abfc10e8634d06187a108e87b",
+    "zh:c88610af9cf957f8dcf4382e0c9ca566ef10e3290f5de01d4d90b2d81b078aa8",
+    "zh:e9562c055a2247d0c287772b55abef468c79f8d66a74780fe1c5e5dae1a284a9",
+    "zh:f7a7c71d28441d925a25c08c4485c015b2d9f0338bc9707443e91ff8e161d3d9",
+    "zh:fee533e81976d0900aa6fa443dc54ef171cbd901847f28a6e8edb1d161fa6fde",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/kubernetes" {
+  version     = "2.35.1"
+  constraints = "~> 2.0, 2.35.1"
+  hashes = [
+    "h1:HqlQaR9X1IeZ2WNdDEvt7rq9iVuBll54SpWOE5bYmZ0=",
+    "zh:12212ca5ae47823ce14bfafb909eeb6861faf1e2435fb2fc4a8b334b3544b5f5",
+    "zh:3f49b3d77182df06b225ab266667de69681c2e75d296867eb2cf06a8f8db768c",
+    "zh:40832494d19f8a2b3cd0c18b80294d0b23ef6b82f6f6897b5fe00248a9997460",
+    "zh:739a5ddea61a77925ee7006a29c8717377a2e9d0a79a0bbd98738d92eec12c0d",
+    "zh:a02b472021753627c5c39447a56d125a32214c29ff9108fc499f2dcdf4f1cc4f",
+    "zh:b78865b3867065aa266d6758c9601a2756741478f5735a838c20d633d65e085b",
+    "zh:d362e87464683f5632790e66920ea803adb54c2bc0cb24b6fd9a314d2b1efffd",
+    "zh:d98206fe88c2c9a52b8d2d0cb2c877c812a4a51d19f9d8428e63cbd5fd8a304d",
+    "zh:dfa320946b1ce3f3615c42b3447a28dc9f604c06d8b9a6fe289855ab2ade4d11",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:fc1debd2e695b5222d2ccc8b24dab65baba4ee2418ecce944e64d42e79474cb5",
+    "zh:fdaf960443720a238c09e519aeb30faf74f027ac5d1e0a309c3b326888e031d7",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/random" {
+  version     = "3.6.3"
+  constraints = ">= 3.0.0"
+  hashes = [
+    "h1:In4XBRMdhY89yUoTUyar3wDF28RJlDpQzdjahp59FAk=",
+    "zh:04ceb65210251339f07cd4611885d242cd4d0c7306e86dda9785396807c00451",
+    "zh:448f56199f3e99ff75d5c0afacae867ee795e4dfda6cb5f8e3b2a72ec3583dd8",
+    "zh:4b4c11ccfba7319e901df2dac836b1ae8f12185e37249e8d870ee10bb87a13fe",
+    "zh:4fa45c44c0de582c2edb8a2e054f55124520c16a39b2dfc0355929063b6395b1",
+    "zh:588508280501a06259e023b0695f6a18149a3816d259655c424d068982cbdd36",
+    "zh:737c4d99a87d2a4d1ac0a54a73d2cb62974ccb2edbd234f333abd079a32ebc9e",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:a357ab512e5ebc6d1fda1382503109766e21bbfdfaa9ccda43d313c122069b30",
+    "zh:c51bfb15e7d52cc1a2eaec2a903ac2aff15d162c172b1b4c17675190e8147615",
+    "zh:e0951ee6fa9df90433728b96381fb867e3db98f66f735e0c3e24f8f16903f0ad",
+    "zh:e3cdcb4e73740621dabd82ee6a37d6cfce7fee2a03d8074df65086760f5cf556",
+    "zh:eff58323099f1bd9a0bec7cb04f717e7f1b2774c7d612bf7581797e1622613a0",
+  ]
+}

--- a/terraform/modules/airflow/secrets.tf
+++ b/terraform/modules/airflow/secrets.tf
@@ -25,8 +25,12 @@ module "secrets_manager" {
   create_policy = true
   policy_statements = {
     user_access = {
-      sid       = "UserAccess"
-      actions   = ["secretsmanager:GetSecretValue"]
+      sid = "UserAccess"
+      actions = [
+        "secretsmanager:DescribeSecret",
+        "secretsmanager:GetSecretValue",
+        "secretsmanager:PutSecretValue",
+      ]
       resources = ["*"]
       principals = [{
         type        = "AWS"

--- a/terraform/modules/airflow/secrets.tf
+++ b/terraform/modules/airflow/secrets.tf
@@ -32,11 +32,11 @@ module "secrets_manager" {
         type        = "AWS"
         identifiers = ["*"]
       }]
-      conditions = {
+      conditions = [{
         test     = "StringEquals"
         variable = "aws:userName"
         values   = var.configuration.maintainers
-      }
+      }]
     }
   }
 

--- a/terraform/modules/airflow/secrets.tf
+++ b/terraform/modules/airflow/secrets.tf
@@ -23,7 +23,9 @@ module "secrets_manager" {
 
   policy_statements = {
     user_access = {
-      sid = "UserAccess"
+      sid       = "UserAccess"
+      actions   = ["secretsmanager:GetSecretValue"]
+      resources = ["*"]
       principals = [{
         type        = "AWS"
         identifiers = ["*"]

--- a/terraform/modules/airflow/secrets.tf
+++ b/terraform/modules/airflow/secrets.tf
@@ -39,7 +39,7 @@ module "secrets_manager" {
       conditions = [{
         test     = "StringEquals"
         variable = "aws:userName"
-        values   = lower(var.configuration.maintainers)
+        values   = [for maintainer in var.configuration.maintainers : lower(maintainer)]
       }]
     }
   }

--- a/terraform/modules/airflow/secrets.tf
+++ b/terraform/modules/airflow/secrets.tf
@@ -39,7 +39,7 @@ module "secrets_manager" {
       conditions = [{
         test     = "StringEquals"
         variable = "aws:userName"
-        values   = var.configuration.maintainers
+        values   = lower(var.configuration.maintainers)
       }]
     }
   }

--- a/terraform/modules/airflow/secrets.tf
+++ b/terraform/modules/airflow/secrets.tf
@@ -21,6 +21,21 @@ module "secrets_manager" {
     }
   }
 
+  policy_statements = {
+    user_access = {
+      sid = "UserAccess"
+      principals = [{
+        type        = "AWS"
+        identifiers = ["*"]
+      }]
+      condition = {
+        test     = "StringEquals"
+        variable = "aws:userName"
+        values   = var.configuration.maintainers
+      }
+    }
+  }
+
   secret_string         = "CHANGEME"
   ignore_secret_changes = true
 }
@@ -42,7 +57,8 @@ resource "kubernetes_manifest" "external_secret" {
         "name" = "analytical-platform-data-production"
       }
       "target" = {
-        "name" = "${var.project}-${var.workflow}-${each.key}"
+        "name"           = "${var.project}-${var.workflow}-${each.key}"
+        "deletionPolicy" = "Delete"
       }
       "data" = [
         {

--- a/terraform/modules/airflow/secrets.tf
+++ b/terraform/modules/airflow/secrets.tf
@@ -32,7 +32,7 @@ module "secrets_manager" {
         type        = "AWS"
         identifiers = ["*"]
       }]
-      condition = {
+      conditions = {
         test     = "StringEquals"
         variable = "aws:userName"
         values   = var.configuration.maintainers

--- a/terraform/modules/airflow/secrets.tf
+++ b/terraform/modules/airflow/secrets.tf
@@ -21,6 +21,8 @@ module "secrets_manager" {
     }
   }
 
+
+  create_policy = true
   policy_statements = {
     user_access = {
       sid       = "UserAccess"


### PR DESCRIPTION
This pull request:

- Allows `maintainers` to update Secrets Manager permissions
- Adds a Terraform lockfile
- Updates Terraform directory in Dependabot

TODO:

- [x] lowercase strings

Signed-off-by: Jacob Woffenden <jacob.woffenden@justice.gov.uk> 