### PR TITLE
⚙️ Allow multi-task jobs to specify global environment variables

### DIFF
--- a/environments/development/analytical-platform/example-multi-task/workflow.yml
+++ b/environments/development/analytical-platform/example-multi-task/workflow.yml
@@ -2,6 +2,8 @@
 dag:
   repository: moj-analytical-services/analytical-platform-airflow-python-example
   tag: 2.0.0
+  env_vars:
+    FOO: "bar"
   tasks:
     init:
       env_vars:
@@ -17,6 +19,7 @@ dag:
     phase-three:
       env_vars:
         MODE: "benchmark"
+        FOO: "baz"
       compute_profile: gpu-spot-8vcpu-32gb
       dependencies: [phase-one, phase-two]
 

--- a/scripts/workflow_generator/main.py
+++ b/scripts/workflow_generator/main.py
@@ -7,8 +7,16 @@ import os
 import yaml
 from jinja2 import Environment, FileSystemLoader
 
+# Custom filter to merge dictionaries
+def merge_dicts(dict1, dict2):
+    result = dict1.copy()
+    result.update(dict2)
+    return result
+
+
 # Load Jinja template
 env = Environment(loader=FileSystemLoader("."))
+env.filters['merge_dicts'] = merge_dicts
 template = env.get_template("scripts/workflow_generator/templates/workflow.yml.j2")
 
 # Loop over environments

--- a/scripts/workflow_generator/templates/workflow.yml.j2
+++ b/scripts/workflow_generator/templates/workflow.yml.j2
@@ -15,9 +15,10 @@
       task_id: {{ meta.project }}-{{ meta.workflow }}-{{ task_name }}
       compute_profile: {{ task.compute_profile or dag.compute_profile or "general-spot-1vcpu-4gb" }}
       image: 509399598587.dkr.ecr.eu-west-2.amazonaws.com/{{ dag.repository }}:{{ dag.tag }}
-      {%- if task.env_vars %}
+      {%- if task.env_vars or dag.env_vars %}
+      {%- set merged_env_vars = dag.env_vars | default({}) | merge_dicts(task.env_vars | default({})) %}
       env_vars:
-        {%- for k, v in task.env_vars.items() %}
+        {%- for k, v in merged_env_vars.items() %}
         {{ k }}: {{ v }}
         {%- endfor %}
       {%- endif %}


### PR DESCRIPTION
Fixes https://github.com/ministryofjustice/analytical-platform/issues/6872

## Proposed Changes

- Adds `merge_dicts` function to `scripts/workflow_generator/main.py`
- Adds logic for merging two dictionaries

## Examples

### No environment variables

input:

```yaml
...
  tasks:
    first_task: {}
    second_task: {}
```

output:

```yaml
...
  tasks:
    first_task:
      operator: analytical_platform.standard_operator.AnalyticalPlatformStandardOperator
      name: analytical-platform-example-env-vars-first_task
      task_id: analytical-platform-example-env-vars-first_task
      compute_profile: general-spot-1vcpu-4gb
      image: 509399598587.dkr.ecr.eu-west-2.amazonaws.com/moj-analytical-services/analytical-platform-airflow-python-example:2.0.0
      environment: development
      project: analytical-platform
      workflow: example-env-vars
    second_task:
      operator: analytical_platform.standard_operator.AnalyticalPlatformStandardOperator
      name: analytical-platform-example-env-vars-second_task
      task_id: analytical-platform-example-env-vars-second_task
      compute_profile: general-spot-1vcpu-4gb
      image: 509399598587.dkr.ecr.eu-west-2.amazonaws.com/moj-analytical-services/analytical-platform-airflow-python-example:2.0.0
      environment: development
      project: analytical-platform
      workflow: example-env-vars
```

### Task level environment variables

input:

```yaml
...
  tasks:
    first_task: {}
    second_task:
      env_vars:
        EXAMPLE_ENV_VAR: "example-value"
```

output:

```yaml
...
  tasks:
    first_task:
      operator: analytical_platform.standard_operator.AnalyticalPlatformStandardOperator
      name: analytical-platform-example-env-vars-first_task
      task_id: analytical-platform-example-env-vars-first_task
      compute_profile: general-spot-1vcpu-4gb
      image: 509399598587.dkr.ecr.eu-west-2.amazonaws.com/moj-analytical-services/analytical-platform-airflow-python-example:2.0.0
      environment: development
      project: analytical-platform
      workflow: example-env-vars
    second_task:
      operator: analytical_platform.standard_operator.AnalyticalPlatformStandardOperator
      name: analytical-platform-example-env-vars-second_task
      task_id: analytical-platform-example-env-vars-second_task
      compute_profile: general-spot-1vcpu-4gb
      image: 509399598587.dkr.ecr.eu-west-2.amazonaws.com/moj-analytical-services/analytical-platform-airflow-python-example:2.0.0
      env_vars:
        EXAMPLE_ENV_VAR: example-value
      environment: development
      project: analytical-platform
      workflow: example-env-vars
```

### Global environment variables

input:

```yaml
...
  env_vars:
    EXAMPLE_ENV_VAR: "example-value"
  tasks:
    first_task: {}
    second_task: {}
```

output:

```yaml
...
  tasks:
    first_task:
      operator: analytical_platform.standard_operator.AnalyticalPlatformStandardOperator
      name: analytical-platform-example-env-vars-first_task
      task_id: analytical-platform-example-env-vars-first_task
      compute_profile: general-spot-1vcpu-4gb
      image: 509399598587.dkr.ecr.eu-west-2.amazonaws.com/moj-analytical-services/analytical-platform-airflow-python-example:2.0.0
      env_vars:
        EXAMPLE_ENV_VAR: example-value
      environment: development
      project: analytical-platform
      workflow: example-env-vars
    second_task:
      operator: analytical_platform.standard_operator.AnalyticalPlatformStandardOperator
      name: analytical-platform-example-env-vars-second_task
      task_id: analytical-platform-example-env-vars-second_task
      compute_profile: general-spot-1vcpu-4gb
      image: 509399598587.dkr.ecr.eu-west-2.amazonaws.com/moj-analytical-services/analytical-platform-airflow-python-example:2.0.0
      env_vars:
        EXAMPLE_ENV_VAR: example-value
      environment: development
      project: analytical-platform
      workflow: example-env-vars
```

### Task overriding global environment variables

input:

```yaml
...
  env_vars:
    EXAMPLE_ENV_VAR: "example-value"
  tasks:
    first_task: {}
    second_task:
      env_vars:
        EXAMPLE_ENV_VAR: "override-example-value"
```

output:

```yaml
...
  tasks:
    first_task:
      operator: analytical_platform.standard_operator.AnalyticalPlatformStandardOperator
      name: analytical-platform-example-env-vars-first_task
      task_id: analytical-platform-example-env-vars-first_task
      compute_profile: general-spot-1vcpu-4gb
      image: 509399598587.dkr.ecr.eu-west-2.amazonaws.com/moj-analytical-services/analytical-platform-airflow-python-example:2.0.0
      env_vars:
        EXAMPLE_ENV_VAR: example-value
      environment: development
      project: analytical-platform
      workflow: example-env-vars
    second_task:
      operator: analytical_platform.standard_operator.AnalyticalPlatformStandardOperator
      name: analytical-platform-example-env-vars-second_task
      task_id: analytical-platform-example-env-vars-second_task
      compute_profile: general-spot-1vcpu-4gb
      image: 509399598587.dkr.ecr.eu-west-2.amazonaws.com/moj-analytical-services/analytical-platform-airflow-python-example:2.0.0
      env_vars:
        EXAMPLE_ENV_VAR: override-example-value
      environment: development
      project: analytical-platform
      workflow: example-env-vars
```

Signed-off-by: Jacob Woffenden <jacob.woffenden@justice.gov.uk>