### PR TITLE
🌍 Add default `AIRFLOW_ENVIRONMENT` variable

### DIFF
--- a/airflow/analytical_platform/standard_operator.py
+++ b/airflow/analytical_platform/standard_operator.py
@@ -34,6 +34,7 @@ class AnalyticalPlatformStandardOperator(KubernetesPodOperator):
             "AWS_DEFAULT_EXTRACT_REGION": "eu-west-1",
             "AWS_METADATA_SERVICE_TIMEOUT": "60",
             "AWS_METADATA_SERVICE_NUM_ATTEMPTS": "5",
+            "AIRFLOW_ENVIRONMENT": environment.upper()
         }
 
         for k, v in std_envs.items():


### PR DESCRIPTION
## Proposed Changes

- Adds a new default variable of `AIRFLOW_ENVIRONMENT` which is set to the `environment` passed to `AnalyticalPlatformStandardOperator`

Signed-off-by: Jacob Woffenden <jacob.woffenden@justice.gov.uk>