### PR TITLE
Address matching test

### DIFF
--- a/environments/test/data-linking/train_address_matching/workflow.yml
+++ b/environments/test/data-linking/train_address_matching/workflow.yml
@@ -1,0 +1,12 @@
+---
+dag:
+  repository: moj-analytical-services/airflow_train_address_matching
+  tag: v0.0.2
+  compute_profile: general-spot-120vcpu-500gb
+
+maintainers:
+  - robinl
+
+tags:
+  business_unit: HQ
+  owner: robin.linacre@justice.gov.uk


### PR DESCRIPTION
Initial test of the new `general-spot-120vcpu-500gb` functionality

No sensitive data access needed, it just runs a simple script that checks the dependencies have correctly installed