### PR TITLE
🗺️ Add Helm chart for External Secret management

### DIFF
--- a/.github/linters/.yaml-lint.yml
+++ b/.github/linters/.yaml-lint.yml
@@ -1,0 +1,11 @@
+---
+extends: default
+
+ignore:
+  - "**/modules/airflow/src/helm/charts/external-secret/templates/*.yaml"
+
+rules:
+  line-length:
+    max: 80
+    level: warning
+

--- a/.github/linters/.yaml-lint.yml
+++ b/.github/linters/.yaml-lint.yml
@@ -8,4 +8,3 @@ rules:
   line-length:
     max: 80
     level: warning
-

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -34,7 +34,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VALIDATE_JSCPD: false
-          VALIDATE_KUBECONFORM: false
+          VALIDATE_KUBERNETES_KUBECONFORM: false # Disabling as it cannot process Helm charts
           # I promise this is temporary
           VALIDATE_PYTHON: false
           VALIDATE_PYTHON_BLACK: false

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -34,6 +34,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VALIDATE_JSCPD: false
+          VALIDATE_KUBECONFORM: false
           # I promise this is temporary
           VALIDATE_PYTHON: false
           VALIDATE_PYTHON_BLACK: false

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -24,8 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # environment: [development, test, production]
-        environment: [development]
+        environment: [development, test, production]
     defaults:
       run:
         working-directory: terraform
@@ -68,7 +67,7 @@ jobs:
           terraform plan -out=${{ matrix.environment }}.tfplan -input=false
 
       - name: Terraform Apply
-        # if: github.ref == 'refs/heads/main'
+        if: github.ref == 'refs/heads/main'
         id: terraform_apply
         shell: bash
         run: |

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -24,7 +24,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        environment: [development, test, production]
+        # environment: [development, test, production]
+        environment: [development]
     defaults:
       run:
         working-directory: terraform
@@ -67,7 +68,7 @@ jobs:
           terraform plan -out=${{ matrix.environment }}.tfplan -input=false
 
       - name: Terraform Apply
-        if: github.ref == 'refs/heads/main'
+        # if: github.ref == 'refs/heads/main'
         id: terraform_apply
         shell: bash
         run: |

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,2 @@
 .devcontainer/devcontainer-lock.json
+terraform/modules/airflow/src/helm/charts/external-secret/templates/external-secret.yaml

--- a/environments/development/analytical-platform/example/workflow.yml
+++ b/environments/development/analytical-platform/example/workflow.yml
@@ -15,6 +15,7 @@ maintainers:
 secrets:
   - api-key
   - user
+  - password
 
 tags:
   business_unit: Central Digital

--- a/environments/development/analytical-platform/example/workflow.yml
+++ b/environments/development/analytical-platform/example/workflow.yml
@@ -14,6 +14,7 @@ maintainers:
 
 secrets:
   - api-key
+  - user
 
 tags:
   business_unit: Central Digital

--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -6,6 +6,7 @@ provider "registry.terraform.io/hashicorp/aws" {
   constraints = ">= 4.0.0, >= 5.0.0, ~> 5.0, 5.91.0"
   hashes = [
     "h1:18BGTHTABfTZdeKcn4181ZZGVxTWt1mP52f6TZ9E0hQ=",
+    "h1:rqkcSC4Ou2D7QZTrm/VU+71Ulqqwp8mU9jx3FVYnMCo=",
     "zh:03ee14261b25aee94c735ed6ef7cce47900ab7bdf462335432ca034d0ba74ca2",
     "zh:32a3759049c9c2cd041d1257cf16cb90a5ce586e1d0a6fe5f8ebd0ec1ba8e071",
     "zh:334db69bc6d8643ec4ea432f0e54e851c2394bbe889cca29ca5029db0e4699e8",
@@ -24,11 +25,32 @@ provider "registry.terraform.io/hashicorp/aws" {
   ]
 }
 
+provider "registry.terraform.io/hashicorp/helm" {
+  version     = "2.17.0"
+  constraints = "2.17.0"
+  hashes = [
+    "h1:K5FEjxvDnxb1JF1kG1xr8J3pNGxoaR3Z0IBG9Csm/Is=",
+    "zh:06fb4e9932f0afc1904d2279e6e99353c2ddac0d765305ce90519af410706bd4",
+    "zh:104eccfc781fc868da3c7fec4385ad14ed183eb985c96331a1a937ac79c2d1a7",
+    "zh:129345c82359837bb3f0070ce4891ec232697052f7d5ccf61d43d818912cf5f3",
+    "zh:3956187ec239f4045975b35e8c30741f701aa494c386aaa04ebabffe7749f81c",
+    "zh:66a9686d92a6b3ec43de3ca3fde60ef3d89fb76259ed3313ca4eb9bb8c13b7dd",
+    "zh:88644260090aa621e7e8083585c468c8dd5e09a3c01a432fb05da5c4623af940",
+    "zh:a248f650d174a883b32c5b94f9e725f4057e623b00f171936dcdcc840fad0b3e",
+    "zh:aa498c1f1ab93be5c8fbf6d48af51dc6ef0f10b2ea88d67bcb9f02d1d80d3930",
+    "zh:bf01e0f2ec2468c53596e027d376532a2d30feb72b0b5b810334d043109ae32f",
+    "zh:c46fa84cc8388e5ca87eb575a534ebcf68819c5a5724142998b487cb11246654",
+    "zh:d0c0f15ffc115c0965cbfe5c81f18c2e114113e7a1e6829f6bfd879ce5744fbb",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/kubernetes" {
   version     = "2.36.0"
   constraints = "~> 2.0, 2.36.0"
   hashes = [
     "h1:PjjQs2jN1zKWjDt84r1RK2ffbfi4Y2N3Aoa3avYWMZc=",
+    "h1:vdY0sxo7ahwuz/y7flXTE04tSwn0Zhxyg6n62aTmAHI=",
     "zh:07f38fcb7578984a3e2c8cf0397c880f6b3eb2a722a120a08a634a607ea495ca",
     "zh:1adde61769c50dbb799d8bf8bfd5c8c504a37017dfd06c7820f82bcf44ca0d39",
     "zh:39707f23ab58fd0e686967c0f973c0f5a39c14d6ccfc757f97c345fdd0cd4624",
@@ -45,21 +67,21 @@ provider "registry.terraform.io/hashicorp/kubernetes" {
 }
 
 provider "registry.terraform.io/hashicorp/random" {
-  version     = "3.6.3"
+  version     = "3.7.1"
   constraints = ">= 3.0.0"
   hashes = [
-    "h1:In4XBRMdhY89yUoTUyar3wDF28RJlDpQzdjahp59FAk=",
-    "zh:04ceb65210251339f07cd4611885d242cd4d0c7306e86dda9785396807c00451",
-    "zh:448f56199f3e99ff75d5c0afacae867ee795e4dfda6cb5f8e3b2a72ec3583dd8",
-    "zh:4b4c11ccfba7319e901df2dac836b1ae8f12185e37249e8d870ee10bb87a13fe",
-    "zh:4fa45c44c0de582c2edb8a2e054f55124520c16a39b2dfc0355929063b6395b1",
-    "zh:588508280501a06259e023b0695f6a18149a3816d259655c424d068982cbdd36",
-    "zh:737c4d99a87d2a4d1ac0a54a73d2cb62974ccb2edbd234f333abd079a32ebc9e",
+    "h1:/qtweZW2sk0kBNiQM02RvBXmlVdI9oYqRMCyBZ8XA98=",
+    "zh:3193b89b43bf5805493e290374cdda5132578de6535f8009547c8b5d7a351585",
+    "zh:3218320de4be943e5812ed3de995946056db86eb8d03aa3f074e0c7316599bef",
+    "zh:419861805a37fa443e7d63b69fb3279926ccf98a79d256c422d5d82f0f387d1d",
+    "zh:4df9bd9d839b8fc11a3b8098a604b9b46e2235eb65ef15f4432bde0e175f9ca6",
+    "zh:5814be3f9c9cc39d2955d6f083bae793050d75c572e70ca11ccceb5517ced6b1",
+    "zh:63c6548a06de1231c8ee5570e42ca09c4b3db336578ded39b938f2156f06dd2e",
+    "zh:697e434c6bdee0502cc3deb098263b8dcd63948e8a96d61722811628dce2eba1",
     "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
-    "zh:a357ab512e5ebc6d1fda1382503109766e21bbfdfaa9ccda43d313c122069b30",
-    "zh:c51bfb15e7d52cc1a2eaec2a903ac2aff15d162c172b1b4c17675190e8147615",
-    "zh:e0951ee6fa9df90433728b96381fb867e3db98f66f735e0c3e24f8f16903f0ad",
-    "zh:e3cdcb4e73740621dabd82ee6a37d6cfce7fee2a03d8074df65086760f5cf556",
-    "zh:eff58323099f1bd9a0bec7cb04f717e7f1b2774c7d612bf7581797e1622613a0",
+    "zh:a0b8e44927e6327852bbfdc9d408d802569367f1e22a95bcdd7181b1c3b07601",
+    "zh:b7d3af018683ef22794eea9c218bc72d7c35a2b3ede9233b69653b3c782ee436",
+    "zh:d63b911d618a6fe446c65bfc21e793a7663e934b2fef833d42d3ccd38dd8d68d",
+    "zh:fa985cd0b11e6d651f47cff3055f0a9fd085ec190b6dbe99bf5448174434cdea",
   ]
 }

--- a/terraform/modules/airflow/providers.tf
+++ b/terraform/modules/airflow/providers.tf
@@ -8,6 +8,10 @@ terraform {
         aws.analytical-platform-data-production-eu-west-2
       ]
     }
+    helm = {
+      source  = "hashicorp/helm"
+      version = "~> 2.0"
+    }
     kubernetes = {
       source  = "hashicorp/kubernetes"
       version = "~> 2.0"

--- a/terraform/modules/airflow/secrets.tf
+++ b/terraform/modules/airflow/secrets.tf
@@ -84,7 +84,7 @@ resource "helm_release" "external_secret" {
   for_each = toset(local.secrets_configuration)
 
   name      = "${var.project}-${var.workflow}-${each.key}"
-  chart     = "./src/helm/charts/external-secret"
+  chart     = "${path.module}/src/helm/charts/external-secret"
   namespace = "mwaa"
 
   set {

--- a/terraform/modules/airflow/secrets.tf
+++ b/terraform/modules/airflow/secrets.tf
@@ -48,34 +48,57 @@ module "secrets_manager" {
   ignore_secret_changes = true
 }
 
-resource "kubernetes_manifest" "external_secret" {
+# resource "kubernetes_manifest" "external_secret" {
+#   for_each = toset(local.secrets_configuration)
+
+#   manifest = {
+#     "apiVersion" = "external-secrets.io/v1beta1"
+#     "kind"       = "ExternalSecret"
+#     "metadata" = {
+#       "namespace" = "mwaa"
+#       "name"      = "${var.project}-${var.workflow}-${each.key}"
+#     }
+#     "spec" = {
+#       "refreshInterval" = "5m"
+#       "secretStoreRef" = {
+#         "kind" = "SecretStore"
+#         "name" = "analytical-platform-data-production"
+#       }
+#       "target" = {
+#         "name"           = "${var.project}-${var.workflow}-${each.key}"
+#         "deletionPolicy" = "Delete"
+#       }
+#       "data" = [
+#         {
+#           "remoteRef" = {
+#             "key" = module.secrets_manager[each.key].secret_id
+#           }
+#           "secretKey" = "data"
+#         }
+#       ]
+#     }
+#   }
+# }
+
+resource "helm_release" "external_secret" {
   for_each = toset(local.secrets_configuration)
 
-  manifest = {
-    "apiVersion" = "external-secrets.io/v1beta1"
-    "kind"       = "ExternalSecret"
-    "metadata" = {
-      "namespace" = "mwaa"
-      "name"      = "${var.project}-${var.workflow}-${each.key}"
-    }
-    "spec" = {
-      "refreshInterval" = "5m"
-      "secretStoreRef" = {
-        "kind" = "SecretStore"
-        "name" = "analytical-platform-data-production"
-      }
-      "target" = {
-        "name"           = "${var.project}-${var.workflow}-${each.key}"
-        "deletionPolicy" = "Delete"
-      }
-      "data" = [
-        {
-          "remoteRef" = {
-            "key" = module.secrets_manager[each.key].secret_id
-          }
-          "secretKey" = "data"
-        }
-      ]
-    }
+  name      = "${var.project}-${var.workflow}-${each.key}"
+  chart     = "./src/helm/charts/external-secret"
+  namespace = "mwaa"
+
+  set {
+    name  = "secretName"
+    value = "${var.project}-${var.workflow}-${each.key}"
+  }
+
+  set {
+    name  = "targetName"
+    value = "${var.project}-${var.workflow}-${each.key}"
+  }
+
+  set {
+    name  = "remoteRefKey"
+    value = module.secrets_manager[each.key].secret_id
   }
 }

--- a/terraform/modules/airflow/src/helm/charts/external-secret/.helmignore
+++ b/terraform/modules/airflow/src/helm/charts/external-secret/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/terraform/modules/airflow/src/helm/charts/external-secret/Chart.yaml
+++ b/terraform/modules/airflow/src/helm/charts/external-secret/Chart.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: v2
+name: external-secret
+description: A Helm chart for creating an ExternalSecret
+type: application
+version: 1.0.0

--- a/terraform/modules/airflow/src/helm/charts/external-secret/templates/_helpers.tpl
+++ b/terraform/modules/airflow/src/helm/charts/external-secret/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "external-secret.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "external-secret.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "external-secret.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "external-secret.labels" -}}
+helm.sh/chart: {{ include "external-secret.chart" . }}
+{{ include "external-secret.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "external-secret.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "external-secret.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "external-secret.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "external-secret.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/terraform/modules/airflow/src/helm/charts/external-secret/templates/external-secret.yaml
+++ b/terraform/modules/airflow/src/helm/charts/external-secret/templates/external-secret.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: {{ .Values.secretName }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "external-secret.labels" . | nindent 4 }}
+spec:
+  refreshInterval: 5m
+  secretStoreRef:
+    kind: {{ .Values.secretStoreRefKind }}
+    name: {{ .Values.secretStoreRefName }}
+  target:
+    name: {{ .Values.targetName }}
+    deletePolicy: {{ .Values.deletePolicy }}
+  data:
+    - secretKey: {{ .Values.secretKey }}
+      remoteRef:
+        key: {{ .Values.remoteRefKey }}

--- a/terraform/modules/airflow/src/helm/charts/external-secret/values.yaml
+++ b/terraform/modules/airflow/src/helm/charts/external-secret/values.yaml
@@ -1,0 +1,8 @@
+---
+secretName:
+secretStoreRefKind: SecretStore
+secretStoreRefName: analytical-platform-data-production
+targetName:
+deletePolicy: Delete
+secretKey: data
+remoteRefKey:

--- a/terraform/terraform.tf
+++ b/terraform/terraform.tf
@@ -16,6 +16,10 @@ terraform {
       source  = "hashicorp/aws"
       version = "5.91.0"
     }
+    helm = {
+      source  = "hashicorp/helm"
+      version = "2.17.0"
+    }
     kubernetes = {
       source  = "hashicorp/kubernetes"
       version = "2.36.0"

--- a/terraform/terraform.tf
+++ b/terraform/terraform.tf
@@ -76,3 +76,15 @@ provider "kubernetes" {
     args        = ["scripts/eks-authentication.sh", "analytical-platform-compute-${terraform.workspace}"]
   }
 }
+
+provider "helm" {
+  kubernetes {
+    host                   = jsondecode(data.aws_secretsmanager_secret_version.analytical_platform_compute_cluster_data.secret_string)["analytical-platform-compute-${terraform.workspace}-api-endpoint"]
+    cluster_ca_certificate = base64decode(jsondecode(data.aws_secretsmanager_secret_version.analytical_platform_compute_cluster_data.secret_string)["analytical-platform-compute-${terraform.workspace}-certificate"])
+    exec {
+      api_version = "client.authentication.k8s.io/v1"
+      command     = "bash"
+      args        = ["scripts/eks-authentication.sh", "analytical-platform-compute-${terraform.workspace}"]
+    }
+  }
+}


### PR DESCRIPTION
## Proposed Changes

- Moves the creation of External Secrets to a Helm chart

## Notes

`kubernetes_manifest` is bit of a nightmare resource because it tries to do validation on plan. That means if a workflow is **creating** a Secrets Manager secret **and** an External Secret at the same time (default behaviour), it will throw a big error from the provider. Using `helm_release` is the recommended workaround, and one we've used already for Karpenter's configuration in APC.

Signed-off-by: Jacob Woffenden <jacob.woffenden@justice.gov.uk>