### PR TITLE
🚚 Move NCA to its own project

### DIFF
--- a/environments/development/nca/nca-offloc-dag/workflow.yml
+++ b/environments/development/nca/nca-offloc-dag/workflow.yml
@@ -1,6 +1,6 @@
 dag:
   repository: ministryofjustice/nca-offloc-dag
-  tag: v0.1
+  tag: v0.2
   catchup: false
   depends_on_past: false
   is_paused_upon_creation: false

--- a/environments/development/nca/nca-offloc-dag/workflow.yml
+++ b/environments/development/nca/nca-offloc-dag/workflow.yml
@@ -1,0 +1,43 @@
+dag:
+  repository: ministryofjustice/nca-offloc-dag
+  tag: v0.1
+  catchup: false
+  depends_on_past: false
+  is_paused_upon_creation: false
+  max_active_runs: 1
+  retries: 1
+  retry_delay: 150
+  schedule: "30 2 * * *"
+  start_date: "2025-03-18"
+  tasks:
+    task:
+      compute_profile: "general-on-demand-1vcpu-4gb"
+      env_vars:
+        dev_prod: "dev"
+
+iam:
+  athena: write
+  glue: true
+  kms:
+    - arn:aws:kms:eu-west-2:505940320338:key/a4e16805-b10a-4996-9e90-fefe8674ecc7
+  s3_read_write:
+    - moj-reg-dev/landing/offloc-dev/*
+    - moj-reg-prod/landing/offloc-prod/*
+    - mojap-hub-exports/*
+
+secrets:
+  - user
+  - pass
+
+maintainers:
+  - vonbraunbates
+  - calumabarnett
+
+tags:
+  business_unit: Central Digital
+  owner: francesca.von.braun-bates@justice.gov.uk
+
+notifications:
+  emails:
+    - francesca.von.braun-bates@justice.gov.uk
+  slack_channel: ct-data-engineering


### PR DESCRIPTION
## Proposed Changes

- Moves `nca-offloc-dag` to its own project
- Bumps version (as per #86)
- Removes `iam.bedrock` as it defaults to `false`

Signed-off-by: Jacob Woffenden <jacob.woffenden@justice.gov.uk>