### PR TITLE
🪣 Add `CreateMultipartUpload` to S3 Read/Write

### DIFF
--- a/terraform/modules/airflow/iam-policy.tf
+++ b/terraform/modules/airflow/iam-policy.tf
@@ -82,6 +82,7 @@ data "aws_iam_policy_document" "iam_policy" {
       sid    = "S3ReadWrite"
       effect = "Allow"
       actions = [
+        "s3:CreateMultipartUpload",
         "s3:DeleteObject",
         "s3:DeleteObjectVersion",
         "s3:GetObject",

--- a/terraform/modules/airflow/iam-policy.tf
+++ b/terraform/modules/airflow/iam-policy.tf
@@ -106,6 +106,7 @@ data "aws_iam_policy_document" "iam_policy" {
       sid    = "S3WriteOnly"
       effect = "Allow"
       actions = [
+        "s3:CreateMultipartUpload",
         "s3:DeleteObject",
         "s3:DeleteObjectVersion",
         "s3:PutObject",


### PR DESCRIPTION
## Proposed Changes

- Adds `s3:CreateMultipartUpload` to S3 Read/Write

Signed-off-by: Jacob Woffenden <jacob.woffenden@justice.gov.uk>