### PR TITLE
Create DAG to Run Python Notebook for Data Extraction and S3 Upload

### DIFF
--- a/environments/development/analytical-platform/crowncourtrpt/workflow.yml
+++ b/environments/development/analytical-platform/crowncourtrpt/workflow.yml
@@ -1,0 +1,10 @@
+dag:
+  repository: moj-analytical-services/CourtCaseLoad
+  tag: v1.0.4  
+
+maintainers:
+  - fogunpola
+
+tags:
+  business_unit: HMCTS
+  owner: "flo.ogunpola@justice.gov.uk"  

--- a/environments/development/analytical-platform/crowncourtrpt/workflow.yml
+++ b/environments/development/analytical-platform/crowncourtrpt/workflow.yml
@@ -8,3 +8,9 @@ maintainers:
 tags:
   business_unit: HMCTS
   owner: "flo.ogunpola@justice.gov.uk"  
+
+tasks:
+  - id: execute_notebook
+    operator: PapermillOperator
+    input_notebook: "/court_caseload_wb.ipynb"
+    output_notebook: "/tmp/notebook_output.ipynb"


### PR DESCRIPTION
This pull request introduces a new DAG in the development environment. The DAG is designed to execute a Python notebook located within the repository. The notebook performs the following key tasks:

Extract Data from Athena:
The notebook connects to AWS Athena, runs the necessary queries, and extracts the required data.

Push Extracted Data to S3:
The extracted data is then pushed to a specified Amazon S3 bucket for further processing or storage.