### PR TITLE
🤖 Add OS to Trivy scanning

### DIFF
--- a/.github/workflows/workflow-validation.yml
+++ b/.github/workflows/workflow-validation.yml
@@ -321,7 +321,7 @@ jobs:
           image-ref: 509399598587.dkr.ecr.eu-west-2.amazonaws.com/${{ env.ecr-repository }}:${{ env.image-tag }}
           severity: HIGH,CRITICAL
           ignore-unfixed: true
-          vuln-type: library
+          vuln-type: library, os
           timeout: 10m0s
           exit-code: 1
 


### PR DESCRIPTION
## Proposed Changes

- Adds `os` to Trivy scanning, this will highlight anyway OS CVEs in scanning, which will indicate if
  a) a new CVE is in the latest base image
  b) a user is using an older version

Signed-off-by: Jacob Woffenden <jacob.woffenden@justice.gov.uk>