### PR TITLE
🔍 Remove `vuln-type` reverting to default

### DIFF
--- a/.github/workflows/workflow-validation.yml
+++ b/.github/workflows/workflow-validation.yml
@@ -321,7 +321,6 @@ jobs:
           image-ref: 509399598587.dkr.ecr.eu-west-2.amazonaws.com/${{ env.ecr-repository }}:${{ env.image-tag }}
           severity: HIGH,CRITICAL
           ignore-unfixed: true
-          vuln-type: library, os
           timeout: 10m0s
           exit-code: 1
 


### PR DESCRIPTION
## Proposed Changes

- https://github.com/ministryofjustice/analytical-platform-airflow/pull/111 introduced a breaking change, so removing `vuln-type` so this action uses its [default](https://github.com/aquasecurity/trivy-action/blob/master/action.yaml#L28-L31), which is what we want anyway 

Signed-off-by: Jacob Woffenden <jacob.woffenden@justice.gov.uk>