### PR TITLE
🪣  Add MLflow bucket to MLops training Airflow workflow

### DIFF
--- a/environments/development/mlops/ml-training/workflow.yml
+++ b/environments/development/mlops/ml-training/workflow.yml
@@ -12,6 +12,7 @@ iam:
     - alpha-mlops-examples/insurance_example/data/*
   s3_write_only:
     - alpha-mlops-examples/insurance_example/model/*
+    - alpha-analytical-platform-mlflow-development/*
 
 secrets:
   - mlflow-tracking-username


### PR DESCRIPTION
Adding `alpha-analytical-platform-mlflow-development` to the workflow for the MLOps training airflow so MLflow can write the model to the bucket.