### PR TITLE
🪣  Using S3 folder for config loading

### DIFF
--- a/environments/development/mlops/ml-training/workflow.yml
+++ b/environments/development/mlops/ml-training/workflow.yml
@@ -1,7 +1,7 @@
 ---
 dag:
   repository: moj-analytical-services/airflow_mlops_training_example
-  tag: 1.1.6
+  tag: 1.1.8
   compute_profile: general-spot-64vcpu-256gb
 
 maintainers:
@@ -10,6 +10,7 @@ maintainers:
 iam:
   s3_read_only:
     - alpha-mlops-examples/insurance_example/data/*
+    - alpha-mlops-examples/insurance_example/config/*
   s3_write_only:
     - alpha-mlops-examples/insurance_example/model/*
     - alpha-analytical-platform-mlflow-development/*


### PR DESCRIPTION
Work around/solution for https://github.com/ministryofjustice/analytical-platform/issues/7557 is to use s3 to save and change a config file. Testing here.

Changes include underlying code changes to use the S3 bucket and also adding read permissions to the config folder.