### PR TITLE
EM: FMS fix: use run date

### DIFF
--- a/environments/test/electronic-monitoring-data-store/load-fms/workflow.yml
+++ b/environments/test/electronic-monitoring-data-store/load-fms/workflow.yml
@@ -14,6 +14,8 @@ dag:
     AWS_DEFAULT_REGION: "eu-west-2"
     AWS_ATHENA_QUERY_EXTRACT_REGION: "eu-west-2"
     AWS_DEFAULT_EXTRACT_REGION: "eu-west-2"
+    DELIVERY_DATE: |
+      {{ ti.run_date }}
 
 notifications:
   emails:


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

uses ti:run_date

## Type of change

Please delete options that are not relevant.

- [x] Bugfix (non-breaking change which fixes an issue)

