### PR TITLE
🕛 Set `max_session_duration` to `43200`

### DIFF
--- a/terraform/modules/airflow/iam-policy.tf
+++ b/terraform/modules/airflow/iam-policy.tf
@@ -156,7 +156,7 @@ module "iam_policy" {
   count = length(local.iam_external_role) > 0 ? 0 : 1
 
   source  = "terraform-aws-modules/iam/aws//modules/iam-policy"
-  version = "5.52.2"
+  version = "5.55.0"
 
   providers = {
     aws = aws.analytical-platform-data-production-eu-west-2

--- a/terraform/modules/airflow/iam-role.tf
+++ b/terraform/modules/airflow/iam-role.tf
@@ -5,13 +5,15 @@ module "iam_role" {
   count = length(local.iam_external_role) == 0 ? 1 : 0
 
   source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
-  version = "5.52.2"
+  version = "5.55.0"
 
   providers = {
     aws = aws.analytical-platform-data-production-eu-west-2
   }
 
   role_name = "airflow-${var.environment}-${var.project}-${var.workflow}"
+
+  max_session_duration = 43200
 
   oidc_providers = {
     main = {


### PR DESCRIPTION
## Proposed Changes

- Sets `max_session_duration` to `43200`, which is 12 hours
- Updates IAM Terraform module version

Signed-off-by: Jacob Woffenden <jacob.woffenden@justice.gov.uk>