### PR TITLE
corp.report-extractor - copy dev DAG to test

### DIFF
--- a/environments/test/corp/report-extractor/workflow.yml
+++ b/environments/test/corp/report-extractor/workflow.yml
@@ -1,0 +1,25 @@
+---
+dag:
+  repository: moj-analytical-services/airflow-report-extractor
+  tag: 0.0.5
+  env_vars:
+    OUTPATH: "s3://alpha-everyone/airflow-example/wto_demo/"
+    URL: "https://sop.govsharedservices.gov.uk:4470/SplashBI/en_US/Login.html"
+
+iam:
+  s3_read_write:
+    - alpha-everyone/airflow-example/wto_demo/*
+
+notifications:
+  slack_channel: dmet-corp-notifications
+
+  emails:
+    - william.orr@justice.gov.uk
+    - Supratik.Chowdhury@justice.gov.uk
+
+maintainers:
+  - williamorrie
+
+tags:
+  business_unit: Central Digital
+  owner: william.orr@justice.gov.uk


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Description

Promoting corp.report-extractor from DEV to TEST env. 
As per [AP Guidance](https://user-guidance.analytical-platform.service.justice.gov.uk/services/airflow/index.html#concepts:~:text=Please%20note%3A%20development%20is%20not%20connected%20to%20the%20MoJO%20Transit%20Gateway) `development is not connected to the MoJO Transit Gateway`