### PR TITLE
Add workflow.yml for published stats

### DIFF
--- a/environments/development/govuk-published-stats/wkly-pris-pop-stats/workflow.yml
+++ b/environments/development/govuk-published-stats/wkly-pris-pop-stats/workflow.yml
@@ -1,0 +1,16 @@
+---
+dag:
+  repository: moj-analytical-services/airflow-govuk-weekly-prison-stats-etl
+  tag: v0.1.3
+
+iam:
+  athena: write
+  s3_read_write:
+    - alpha-weekly-prison-pop-cap-publication-data/*
+
+maintainers:
+  - swalla-moj
+
+tags:
+  business_unit: HMPPS
+  owner: steven.wallace1@justice.gov.uk


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Description
Airflow task to trigger script which will pull published prison statistics files from gov.uk website and upload to athena

## Type of change
Please delete options that are not relevant.

[ x] New feature (non-breaking change which adds functionality)

## Additional Notes
Link to associated repository: https://github.com/moj-analytical-services/airflow-govuk-weekly-prison-stats-etl
