### PR TITLE
✍️  Consume Commit Signature Verification workflow

### DIFF
--- a/.github/workflows/check-commit-signatures.yml
+++ b/.github/workflows/check-commit-signatures.yml
@@ -3,31 +3,15 @@ name: ✍️ Check Commit Signatures
 
 on:
   pull_request:
-    types: [opened, synchronize]
+    branches:
+      - main
+
+permissions: {}
 
 jobs:
-  check-signatures:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check for unverified commits
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const prNumber = context.payload.pull_request.number;
-            const { data: commits } = await github.rest.pulls.listCommits({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: prNumber,
-            });
-
-            const unverified = commits.filter(commit => !commit.commit.verification.verified);
-
-            if (unverified.length > 0) {
-              const message = `⚠️ This PR contains ${unverified.length} commit(s) without verified signatures. Please sign your commits. More information on this is available [here](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).`;
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: prNumber,
-                body: message,
-              });
-            }
+  super-linter:
+    name: Check Commit Signatures
+    permissions:
+      contents: read
+      pull-requests: write
+    uses: ministryofjustice/analytical-platform-github-actions/.github/workflows/reusable-check-commit-signatures.yml@828b3c86946eb2f3c551e90d7f1ee551448ae427 # v2.5.0

--- a/.github/workflows/check-commit-signatures.yml
+++ b/.github/workflows/check-commit-signatures.yml
@@ -1,0 +1,33 @@
+---
+name: ✍️ Check Commit Signatures
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  check-signatures:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for unverified commits
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prNumber = context.payload.pull_request.number;
+            const { data: commits } = await github.rest.pulls.listCommits({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber,
+            });
+
+            const unverified = commits.filter(commit => !commit.commit.verification.verified);
+
+            if (unverified.length > 0) {
+              const message = `⚠️ This PR contains ${unverified.length} commit(s) without verified signatures. Please sign your commits. More information on this is available [here](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).`;
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                body: message,
+              });
+            }

--- a/.github/workflows/check-commit-signatures.yml
+++ b/.github/workflows/check-commit-signatures.yml
@@ -14,4 +14,4 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-    uses: ministryofjustice/analytical-platform-github-actions/.github/workflows/reusable-check-commit-signatures.yml@828b3c86946eb2f3c551e90d7f1ee551448ae427 # v2.5.0
+    uses: ministryofjustice/analytical-platform-github-actions/.github/workflows/reusable-commit-signature-checker.yml@828b3c86946eb2f3c551e90d7f1ee551448ae427 # v2.5.0

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -13,4 +13,4 @@ jobs:
     name: Dependency Review
     permissions:
       contents: read
-    uses: ministryofjustice/analytical-platform-github-actions/.github/workflows/reusable-dependency-review.yml@8ab46c24a6f48d0b6f18e9dfeb04957667d65ae1 # v2.3.0
+    uses: ministryofjustice/analytical-platform-github-actions/.github/workflows/reusable-dependency-review.yml@828b3c86946eb2f3c551e90d7f1ee551448ae427 # v2.5.0

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -15,7 +15,7 @@ jobs:
       contents: read
       packages: read
       statuses: write
-    uses: ministryofjustice/analytical-platform-github-actions/.github/workflows/reusable-super-linter.yml@8ab46c24a6f48d0b6f18e9dfeb04957667d65ae1 # v2.3.0
+    uses: ministryofjustice/analytical-platform-github-actions/.github/workflows/reusable-super-linter.yml@828b3c86946eb2f3c551e90d7f1ee551448ae427 # v2.5.0
     with:
       # VALIDATE_KUBERNETES_KUBECONFORM is set to false as it cannot process Helm charts
       # VALIDATE_PYTHON_* are set to false as we need to revisit the Python from a linting perspective

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -15,4 +15,4 @@ jobs:
       actions: read
       contents: read
       security-events: write
-    uses: ministryofjustice/analytical-platform-github-actions/.github/workflows/reusable-zizmor.yml@8ab46c24a6f48d0b6f18e9dfeb04957667d65ae1 # v2.3.0
+    uses: ministryofjustice/analytical-platform-github-actions/.github/workflows/reusable-zizmor.yml@828b3c86946eb2f3c551e90d7f1ee551448ae427 # v2.5.0

--- a/environments/production/probation-performance/performance/workflow.yml
+++ b/environments/production/probation-performance/performance/workflow.yml
@@ -1,0 +1,21 @@
+dag:
+  repository: moj-analytical-services/probation-performance-extraction
+  tag: v0.0.10
+  schedule: "30 6 * * *"
+
+maintainers:
+  - hcgk
+  - yvette-justice
+
+notifications:
+  emails:
+    - henry.goldsack@justice.gov.uk
+
+tags:
+  business_unit: HQ
+  owner: communityperformanceenquiries@justice.gov.uk
+
+iam:
+  athena: read
+  s3_write_only:
+    - alpha_probation_performance_extraction/*

--- a/terraform/modules/airflow/src/helm/charts/external-secret/values.yaml
+++ b/terraform/modules/airflow/src/helm/charts/external-secret/values.yaml
@@ -1,7 +1,7 @@
 ---
 secretName:
 secretStoreRefKind: SecretStore
-secretStoreRefName: analytical-platform-data-production
+secretStoreRefName: analytical-platform-data-production # checkov:skip=CKV_SECRET_6
 targetName:
 deletePolicy: Delete
 secretKey: data


### PR DESCRIPTION
The purpose of this PR is to consume the new workflow created [here](https://github.com/ministryofjustice/analytical-platform-github-actions/pull/27) to comment on PRs which contain commits which are created without signatures, letting users know this is not permitted. It is hoped that this reduces queries to support when this scenario occurs. 

Additionally this PR updates calls to `analytical-platform-github-actions` from v2.3.0 to v2.5.0