### PR TITLE
govuk-prison-pop ver bump to v0.1.8

### DIFF
--- a/environments/development/govuk-published-stats/wkly-pris-pop-stats/workflow.yml
+++ b/environments/development/govuk-published-stats/wkly-pris-pop-stats/workflow.yml
@@ -1,7 +1,7 @@
 ---
 dag:
   repository: moj-analytical-services/airflow-govuk-weekly-prison-stats-etl
-  tag: v0.1.7
+  tag: v0.1.8
 
 iam:
   athena: write


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Description

Version bump for govuk prison population stats to v0.1.8

## Type of change

- [x ] New feature (non-breaking change which adds functionality)
