### PR TITLE
🔧 Add aliases for onecrown hosts 

### DIFF
--- a/airflow/analytical_platform/standard_operator.py
+++ b/airflow/analytical_platform/standard_operator.py
@@ -92,6 +92,18 @@ class AnalyticalPlatformStandardOperator(KubernetesPodOperator):
                 {
                     "ip": "10.168.1.16",
                     "hostnames": ["mi-synapse-dev-ondemand.sql.azuresynapse.net"]
+                },
+                {
+                    "ip": "10.168.5.16",
+                    "hostnames": ["mi-synapse-prod.sql.azuresynapse.net"]
+                },
+                {
+                    "ip": "10.168.5.17",
+                    "hostnames": ["mi-synapse-prod-ondemand.sql.azuresynapse.net"]
+                },
+                {
+                    "ip": "10.168.5.18",
+                    "hostnames": ["mi-synapse-prod.dev.azuresynapse.net"]
                 }
             ]
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Description

Please provide a summary of the changes in this pull request. Include the motivation and context for the change, and list any dependencies required for this change.

This PR is tracked upstream by [#7851](https://github.com/ministryofjustice/analytical-platform/issues/7851) in the analytical-platform repository.

## Type of change

Please delete options that are not relevant.

- [x] Update to existing role

## Additional Notes

This PR adds some aliases so that traffic is routed to endpoints internally, rather than over the internet.
