### PR TITLE
Add secret place holder

### DIFF
--- a/environments/development/pcol/dlt/workflow.yml
+++ b/environments/development/pcol/dlt/workflow.yml
@@ -1,13 +1,13 @@
 dag:
   repository: moj-analytical-services/pcol-pipeline
-  tag: v0.0.8
-  retries: 1
-  retry_delay: 60
+  tag: v0.0.9
+  retries: 3
+  retry_delay: 150
   env_vars:
     AWS_METADATA_SERVICE_TIMEOUT: "60"
     AWS_METADATA_SERVICE_NUM_ATTEMPTS: "5"
     AWS_DEFAULT_REGION: "eu-west-1"
-    MOJAP_IMAGE_VERSION: "v0.0.8"
+    MOJAP_IMAGE_VERSION: "v0.0.9"
     MOJAP_ROLE: "airflow_dev_xhibit_dlt"
 
   tasks:
@@ -136,6 +136,9 @@ iam:
   glue: true
   s3_read_write:
     - alpha-mojap-ccde/dev/pcol_raw_data/*
+
+secrets:
+  - pds
 
 notifications:
   emails:


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Description

In the previous version of Airflow, we used AWS Systems Manager Parameter Store for managing secrets, and it worked because we manually assigned a custom IAM role with appropriate permissions.

However, in the new version of the Analytical Platform Airflow, the IAM role is automatically generated and expects secrets to be retrieved from AWS Secrets Manager instead of Parameter Store.

To align with this change, I’ve updated the DAG to reference the required secret identifiers. This should automatically create the corresponding secret placeholders in AWS Secrets Manager. Once created, I will update the secret values manually via the AWS Console.

Fixes #(issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Update to existing role
- [ ] Documentation update

## Additional Notes

Add any other context or screenshots about the pull request here.
