### PR TITLE
fix: db permissions and aws region defaults

### DIFF
--- a/environments/development/corp/file-load-leavers/workflow.yml
+++ b/environments/development/corp/file-load-leavers/workflow.yml
@@ -6,11 +6,16 @@ dag:
     AFFILE_PIPELINE_NAME: "all-time-wf59-leavers"
     AFFILE_ENV: "dev"
     AFFILE_SCHEMA_CONTRACT: "freeze"
+    AWS_DEFAULT_REGION: "eu-west-1"
+    AWS_ATHENA_QUERY_EXTRACT_REGION: "eu-west-1"
+    AWS_DEFAULT_EXTRACT_REGION: "eu-west-1"
   catchup: false
   max_active_runs: 1
   retries: 0
 
 iam:
+  athena: write
+  glue: true
   s3_read_write:
     - mojap-land-preprod/corporate/report_extractor/splashbi/leavers_daily/data/*
     - mojap-processed/corporate/sop/dev/*


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Description

- Add Athena/Glue permissions for hive creation/update and iceberg DB insert and creation actions (to enable load actions)
- Add AWS default region explicitly into env vars

Fixes #(issue)

## Type of change

- [ ] Bugfix (non-breaking change which fixes an issue)

