### PR TITLE
🔒 Prepare for ESO v1.7.0

### DIFF
--- a/terraform/modules/airflow/secrets.tf
+++ b/terraform/modules/airflow/secrets.tf
@@ -48,38 +48,6 @@ module "secrets_manager" {
   ignore_secret_changes = true
 }
 
-# resource "kubernetes_manifest" "external_secret" {
-#   for_each = toset(local.secrets_configuration)
-
-#   manifest = {
-#     "apiVersion" = "external-secrets.io/v1beta1"
-#     "kind"       = "ExternalSecret"
-#     "metadata" = {
-#       "namespace" = "mwaa"
-#       "name"      = "${var.project}-${var.workflow}-${each.key}"
-#     }
-#     "spec" = {
-#       "refreshInterval" = "5m"
-#       "secretStoreRef" = {
-#         "kind" = "SecretStore"
-#         "name" = "analytical-platform-data-production"
-#       }
-#       "target" = {
-#         "name"           = "${var.project}-${var.workflow}-${each.key}"
-#         "deletionPolicy" = "Delete"
-#       }
-#       "data" = [
-#         {
-#           "remoteRef" = {
-#             "key" = module.secrets_manager[each.key].secret_id
-#           }
-#           "secretKey" = "data"
-#         }
-#       ]
-#     }
-#   }
-# }
-
 resource "helm_release" "external_secret" {
   for_each = toset(local.secrets_configuration)
 

--- a/terraform/modules/airflow/src/helm/charts/external-secret/templates/external-secret.yaml
+++ b/terraform/modules/airflow/src/helm/charts/external-secret/templates/external-secret.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: {{ .Values.secretName }}


### PR DESCRIPTION
## Proposed Changes

- [External Secrets Operator v1.7.0](https://github.com/external-secrets/external-secrets/releases/tag/v0.17.0) introduces a breaking change 😱 

> v0.17.0 Stops serving v1beta1 apis. You need to update your manifests from v1beta1 to v1 prior to updating from v0.16 to v0.17.
> 
> The only change needed is upgrading your manifests to v1 (i.e. removing the beta1 from v1beta1).
> 
> Be sure to do that to all your manifests prior to bumping to v0.17.0! v0.16.2 already supports v1 so this process should be smooth.
> 

Signed-off-by: Jacob Woffenden <jacob.woffenden@justice.gov.uk>