### PR TITLE
updated delivery_date to use airflow ds macro

### DIFF
--- a/environments/test/electronic-monitoring-data-store/load-mdss/workflow.yml
+++ b/environments/test/electronic-monitoring-data-store/load-mdss/workflow.yml
@@ -12,7 +12,7 @@ dag:
     SYSTEM_NAME: "mdss"
     REFRESH_TOTAL_DB: true
     START_DATE: "2025-06-10"
-    DELIVERY_DATE: "2025-06-10"
+    DELIVERY_DATE: "{{ ds }}"
     AWS_DEFAULT_REGION: "eu-west-2"
     AWS_ATHENA_QUERY_EXTRACT_REGION: "eu-west-2"
     AWS_DEFAULT_EXTRACT_REGION: "eu-west-2"


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Description

currently only the hardcoded delivery_date is being loaded. Trying {{ds}} Airflow in built var to fix this issue

Fixes #(issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Update to existing role
- [ ] Documentation update

## Additional Notes

Add any other context or screenshots about the pull request here.
