### PR TITLE
Pcol- added new parameter for networking

### DIFF
--- a/environments/development/pcol/dlt/workflow.yml
+++ b/environments/development/pcol/dlt/workflow.yml
@@ -1,14 +1,14 @@
 dag:
   repository: moj-analytical-services/pcol-pipeline
   tag: v0.0.9
-  retries: 3
+  retries: 2
   retry_delay: 150
+  hmcts_sdp_networking: True
   env_vars:
     AWS_METADATA_SERVICE_TIMEOUT: "60"
     AWS_METADATA_SERVICE_NUM_ATTEMPTS: "5"
     AWS_DEFAULT_REGION: "eu-west-1"
     MOJAP_IMAGE_VERSION: "v0.0.9"
-    MOJAP_ROLE: "airflow_dev_xhibit_dlt"
 
   tasks:
     process-v3-cgi-pcol-claim:


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Description

The DAG is running successfully, but when I looked into the logs, it showed an error message indicating it couldn’t connect to the SDP.

I’ve added a new parameter, hmcts_sdp_networking=True, which might resolve the issue. Let’s give it a try.
Fixes #(issue)

## Type of change

Please delete options that are not relevant.

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Update to existing role
- [ ] Documentation update

## Additional Notes

Add any other context or screenshots about the pull request here.
