### PR TITLE
Seized Media Database NCA Data Share

### DIFF
--- a/environments/development/prison-intel-dsai/nca-datashare/workflow.yml
+++ b/environments/development/prison-intel-dsai/nca-datashare/workflow.yml
@@ -1,0 +1,31 @@
+dag:
+  repository: moj-analytical-services/airflow-pdsai-nca-datashare
+  tag: 0.0.1
+  catchup: false
+  depends_on_past: false
+  is_paused_upon_creation: false
+  max_active_runs: 1
+  retries: 3
+  retry_delay: 100
+  schedule: None
+  start_date: "2025-07-01"
+  tasks:
+    task:
+      compute_profile: "general-on-demand-1vcpu-4gb"
+
+iam:
+  s3_read_write:
+    - alpha-app-bentham-app/*
+    - mojap-hub-exports/nca_seized_media/*
+
+notifications:
+  emails:
+    - matthew.funnell@justice.gov.uk
+  slack_channel: intel-app-maintenance
+
+maintainers:
+  - mattfunnell
+
+tags:
+  business_unit: HMPPS
+  owner: matthew.funnell@justice.gov.uk


### PR DESCRIPTION
Setting up simple Airflow job for SMDb data share with the NCA bi-annually. Converted to airflow since the script takes a long time to run locally, will be triggered manually when needed.

@vonbraunbates would you be able to check the permissions I have on this? The job just copies files from one S3 bucket to another, but not sure if I need any special permissions for being able to copy to the push bucket that you set up for this in `mojap-hub-exports`