### PR TITLE
🛂 Add regex check for param key

### DIFF
--- a/environments/development/analytical-platform/example/workflow.yml
+++ b/environments/development/analytical-platform/example/workflow.yml
@@ -4,7 +4,6 @@ dag:
   tag: 2.11.0-rc1
   params:
     example_param: underscored
-    example-param-two: hyphenated
 
 notifications:
   emails:

--- a/scripts/workflow_generator/templates/workflow.yml.j2
+++ b/scripts/workflow_generator/templates/workflow.yml.j2
@@ -59,7 +59,7 @@
         {%- endfor %}
         {%- if dag.params %}
         {%- for k, v in dag.params.items() %}
-        PARAM_{{ k.replace('-', '_').upper() }}: "{{ '{{ params.' ~ k ~ ' }}' }}"
+        PARAM_{{ k.upper() }}: "{{ '{{ params.' ~ k ~ ' }}' }}"
         {%- endfor %}
         {%- endif %}
       {%- endif %}
@@ -90,7 +90,7 @@
         {%- endif %}
         {%- if dag.params %}
         {%- for k, v in dag.params.items() %}
-        PARAM_{{ k.replace('-', '_').upper() }}: "{{ '{{ params.' ~ k ~ ' }}' }}"
+        PARAM_{{ k.upper() }}: "{{ '{{ params.' ~ k ~ ' }}' }}"
         {%- endfor %}
         {%- endif %}
       {%- endif %}

--- a/scripts/workflow_schema_validation/schema.json
+++ b/scripts/workflow_schema_validation/schema.json
@@ -128,7 +128,8 @@
       },
       "params": {
         "type": "dict",
-        "required": false
+        "required": false,
+        "keysrules": { "type": "string", "regex": "^[a-zA-Z0-9_]+$" }
       },
       "python_dag": { "type": "boolean", "required": false }
     },


### PR DESCRIPTION
## Proposed Changes

- Enforces underscores at the schema level 

## Testing

```yaml
dag:
  repository: moj-analytical-services/analytical-platform-airflow-python-example
  tag: 2.11.0-rc1
  params:
    example_param: underscored
    example-param-1: hyphenated
```

produces

```
$ python scripts/workflow_schema_validation/main.py environments/development/analytical-platform/example/workflow.yml
{
    "dag": [
        {
            "params": [
                {
                    "example-param-1": [
                        "value does not match regex '^[a-zA-Z0-9_]+$'"
                    ]
                }
            ]
        }
    ]
}
```

Signed-off-by: Jacob Woffenden <jacob.woffenden@justice.gov.uk>