### PR TITLE
use date for start_date instead of datetime

### DIFF
--- a/environments/development/opg/sirius-monthly/dag.py
+++ b/environments/development/opg/sirius-monthly/dag.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import date
 from airflow.models import DAG
 from analytical_platform.standard_operator import AnalyticalPlatformStandardOperator
 
@@ -10,7 +10,7 @@ WORKFLOW="PLACEHOLDER_WORKFLOW"
 ENVIRONMENT="PLACEHOLDER_ENVIRONMENT"
 OWNER="PLACEHOLDER_OWNER"
 
-start_date=datetime(2025, 6, 1)
+start_date=date(2025, 6, 1)
 total_workers = 10
 
 default_args = {

--- a/environments/development/opg/sirius-monthly/dag.py
+++ b/environments/development/opg/sirius-monthly/dag.py
@@ -1,4 +1,4 @@
-from datetime import date
+from datetime import datetime
 from airflow.models import DAG
 from analytical_platform.standard_operator import AnalyticalPlatformStandardOperator
 
@@ -10,7 +10,7 @@ WORKFLOW="PLACEHOLDER_WORKFLOW"
 ENVIRONMENT="PLACEHOLDER_ENVIRONMENT"
 OWNER="PLACEHOLDER_OWNER"
 
-start_date=date(2025, 6, 1)
+start_date=datetime(2025, 6, 1)
 total_workers = 10
 
 default_args = {
@@ -35,7 +35,7 @@ base_env_vars={
     "DATABASE_VERSION": "dev",
     "GITHUB_TAG": f"{REPOSITORY_TAG}",
     "ATHENA_DB_PREFIX": "opg",
-    "START_DATE": start_date,
+    "START_DATE": start_date.strftime("%Y-%m-%d"),
 }
 
 def update_env_vars(env_vars: dict[str, str], updates: dict[str, str]) -> dict[str, str]:


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Description

Setting start_date with datetime.date instead of datetime.datetime.
As the YML workflows only generate yyyy/mm/dd, our internal logic was changed to work off just a date
This aligns the python DAG to that convention.