### PR TITLE
Correctly update the env_vars

### DIFF
--- a/environments/development/opg/sirius-monthly/dag.py
+++ b/environments/development/opg/sirius-monthly/dag.py
@@ -39,9 +39,7 @@ base_env_vars={
 }
 
 def update_env_vars(env_vars: dict[str, str], updates: dict[str, str]) -> dict[str, str]:
-    for key, value in updates.items():
-        env_vars[key] = value
-    return env_vars
+    return {**env_vars, **updates}
 
 tasks = {}
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Description

Prevent the base_env_vars being overwritten by each task, resulting in incorrect parameters being passed to tasks.

## Type of change

Please delete options that are not relevant.

- [X] Bugfix (non-breaking change which fixes an issue)
