### PR TITLE
Migrate GPC DAG over from data engineering Airflow

### DIFF
--- a/environments/development/calc-corp-ds/process-gpc-data/workflow.yml
+++ b/environments/development/calc-corp-ds/process-gpc-data/workflow.yml
@@ -1,0 +1,33 @@
+dag:
+  repository: moj-analytical-services/airflow-gpc-anomalies-preprocess
+  tag: v0.2.0-rc1
+  retries: 3
+  retry_delay: 150
+  schedule: "0 2 * * *"
+  tasks:
+    unlock_dev:
+      env_vars:
+        R_CONFIG_ACTIVE: "dev"
+      bash_command: "Rscript scripts/unlock_all_blocks.R"
+    unlock_prod:
+      env_vars:
+        R_CONFIG_ACTIVE: "prod"
+      bash_command: "Rscript scripts/unlock_all_blocks.R"
+
+iam:
+  athena: write
+  s3_read_write:
+    - alpha-app-gpc-anomalies/*
+
+maintainers:
+  - tomd-moj
+  - sheilz81
+
+notifications:
+  emails:
+    - thomas.dykins@justice.gov.uk
+    - sheila.ladva@justice.gov.uk
+
+tags:
+  business_unit: HQ
+  owner: thomas.dykins@justice.gov.uk


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Description

Migrating the existing [DAG for processing Government Procurement Card data](https://github.com/moj-analytical-services/airflow/blob/main/environments/dev/dags/gpc/process_gpc_data.py) over from the data engineering Airflow.

## Type of change

Please delete options that are not relevant.

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Update to existing role
- [ ] Documentation update
