### PR TITLE
🚘 Override Airflow XCom Sidecar settings

### DIFF
--- a/airflow/analytical_platform/standard_operator.py
+++ b/airflow/analytical_platform/standard_operator.py
@@ -11,7 +11,7 @@ from kubernetes.client import models as k8s_models
 
 def override_xcom_sidecar_defaults():
     """Override the default sidecar container for XCom in KubernetesPodOperator"""
-    PodDefaults.SIDECAR_CONTAINER.image = "ghcr.io/ministryofjustice/analytical-platform-airflow-xcom-sidecar:1.0.0-rc2@sha256:1e0adde6f97c66b64bbb213f43d83e0c54e45dcf5422c23628e3a157dc7172ad"
+    PodDefaults.SIDECAR_CONTAINER.image = "ghcr.io/ministryofjustice/analytical-platform-airflow-xcom-sidecar:1.0.0@sha256:83c145bccf9f112b7081759e37823b08d6d4b62cf4cb4573da5265cad1db0904"
     PodDefaults.SIDECAR_CONTAINER.security_context = k8s_models.V1SecurityContext(
         allow_privilege_escalation=False,
         privileged=False,

--- a/airflow/analytical_platform/standard_operator.py
+++ b/airflow/analytical_platform/standard_operator.py
@@ -3,8 +3,22 @@ from typing import Optional
 from airflow.providers.cncf.kubernetes.operators.pod import (
     KubernetesPodOperator,
 )
+from airflow.providers.cncf.kubernetes.utils.xcom_sidecar import (
+    PodDefaults,
+)
 from analytical_platform.compute_profiles import get_compute_profile
+from kubernetes.client import models as k8s_models
 
+def override_xcom_sidecar_defaults():
+    """Override the default sidecar container for XCom in KubernetesPodOperator"""
+    PodDefaults.SIDECAR_CONTAINER.image = "ghcr.io/ministryofjustice/analytical-platform-airflow-xcom-sidecar:1.0.0-rc1@sha256:4378d3e223747478b63c3fb2a262e201e12b0ddc997c8e62f2eecae365b28021"
+    PodDefaults.SIDECAR_CONTAINER.security_context = k8s_models.V1SecurityContext(
+        allow_privilege_escalation=False,
+        privileged=False,
+        run_as_non_root=True,
+        seccomp_profile=k8s_models.V1SeccompProfile(type="RuntimeDefault"),
+        capabilities=k8s_models.V1Capabilities(drop=["ALL"]),
+    )
 
 class AnalyticalPlatformStandardOperator(KubernetesPodOperator):
     def __init__(
@@ -21,6 +35,8 @@ class AnalyticalPlatformStandardOperator(KubernetesPodOperator):
         *args,
         **kwargs,
     ):
+        # Override the default sidecar container for XCom
+        override_xcom_sidecar_defaults()
 
         # Declare any settings that can be updated later
         annotations = {}

--- a/airflow/analytical_platform/standard_operator.py
+++ b/airflow/analytical_platform/standard_operator.py
@@ -11,7 +11,7 @@ from kubernetes.client import models as k8s_models
 
 def override_xcom_sidecar_defaults():
     """Override the default sidecar container for XCom in KubernetesPodOperator"""
-    PodDefaults.SIDECAR_CONTAINER.image = "ghcr.io/ministryofjustice/analytical-platform-airflow-xcom-sidecar:1.0.0-rc1@sha256:4378d3e223747478b63c3fb2a262e201e12b0ddc997c8e62f2eecae365b28021"
+    PodDefaults.SIDECAR_CONTAINER.image = "ghcr.io/ministryofjustice/analytical-platform-airflow-xcom-sidecar:1.0.0-rc2@sha256:1e0adde6f97c66b64bbb213f43d83e0c54e45dcf5422c23628e3a157dc7172ad"
     PodDefaults.SIDECAR_CONTAINER.security_context = k8s_models.V1SecurityContext(
         allow_privilege_escalation=False,
         privileged=False,


### PR DESCRIPTION
Fixes https://github.com/ministryofjustice/analytical-platform/issues/8100

## Proposed Changes

- Overrides XCom Sidecar to use non-root container with required security context

## Notes

Pending merge:

- https://github.com/ministryofjustice/analytical-platform-airflow-xcom-sidecar/pull/1

Signed-off-by: Jacob Woffenden <jacob.woffenden@justice.gov.uk>