### PR TITLE
Add data interval template variables for MDSS

### DIFF
--- a/environments/test/electronic-monitoring-data-store/load-mdss/workflow.yml
+++ b/environments/test/electronic-monitoring-data-store/load-mdss/workflow.yml
@@ -1,7 +1,7 @@
 ---
 dag:
   repository: moj-analytical-services/airflow-load-em-data
-  tag: v0.2.29
+  tag: v0.2.30
   compute_profile: gpu-spot-8vcpu-32gb
   catchup: true
   depends_on_past: false


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Description

We want each Airflow task for EMDS MDSS to load a specific, known slice of the source data. For that to work, we need to pass the logical data interval timestamps from Airflow to the Python script. We pass these values as template variables (which should be populated by Airflow) in the environment variables to enable this.

Implements [ELM-3902](https://dsdmoj.atlassian.net/browse/ELM-3902).

## Type of change

- [x] New feature (non-breaking change which adds functionality)


[ELM-3902]: https://dsdmoj.atlassian.net/browse/ELM-3902?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ