### PR TITLE
Change compute profile

### DIFF
--- a/environments/development/cjsm/cjsm-preprocess/workflow.yml
+++ b/environments/development/cjsm/cjsm-preprocess/workflow.yml
@@ -3,6 +3,7 @@ dag:
   repository: moj-analytical-services/airflow-cjsm-email-traffic-preprocess
   tag: v5.0.4
   python_dag: true
+  compute_profile: "general-on-demand-4vcpu-16gb"
 
 iam:
   athena: read


### PR DESCRIPTION
Change from default to general-on-demand-4vcpu-16gb

<!-- markdownlint-disable MD041 -->

## Description

Change compute profile from default to `general-on-demand-4vcpu-16gb`, as the pipeline was crashing as OOM.

The memory required for the process is ~6GB, and have added on a bit of headroom.

## Type of change

Please delete options that are not relevant.

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Update to existing role
- [ ] Documentation update
