### PR TITLE
Add gpc unlock workflow to production

### DIFF
--- a/environments/production/calc-corp-ds/gpc-unlock/workflow.yml
+++ b/environments/production/calc-corp-ds/gpc-unlock/workflow.yml
@@ -1,0 +1,29 @@
+dag:
+  repository: moj-analytical-services/airflow-gpc-anomalies-preprocess
+  tag: v0.2.1
+  retries: 3
+  retry_delay: 150
+  schedule: "0 2 * * *"
+  tasks:
+    unlock_prod:
+      env_vars:
+        R_CONFIG_ACTIVE: "prod"
+        MODE: "unlock"
+
+iam:
+  athena: write
+  s3_read_write:
+    - alpha-app-gpc-anomalies/*
+
+maintainers:
+  - tomd-moj
+  - sheilz81
+
+notifications:
+  emails:
+    - thomas.dykins@justice.gov.uk
+    - sheila.ladva@justice.gov.uk
+
+tags:
+  business_unit: HQ
+  owner: thomas.dykins@justice.gov.uk


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Description

Adding the 'GPC unlock' workflow to the production environment. It's already running successfully in development.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
