### PR TITLE
Bump image tag in incentives workflow

### DIFF
--- a/environments/development/prison-reoffending-dsai/incentives/workflow.yml
+++ b/environments/development/prison-reoffending-dsai/incentives/workflow.yml
@@ -1,6 +1,6 @@
 dag:
   repository: moj-analytical-services/airflow-digital-incentives
-  tag: v2.0.3
+  tag: v2.1.0
   env_vars:
     ENVIRONMENT: "prod" #to be changed to dev once we have a prod DAG running
   catchup: true


### PR DESCRIPTION
## Description

Bump image tag to add back in old NOMIS religion codes. This fix is needed as data for some religious groups e.g. Muslim and Hindu wasn't showing prior to June 2025.