### PR TITLE
add athena to iam role

### DIFF
--- a/environments/development/cjs-dashboard/r-validation/workflow.yml
+++ b/environments/development/cjs-dashboard/r-validation/workflow.yml
@@ -9,7 +9,7 @@ maintainers:
   - rolakeo-mojo
 
 iam:
-  athena: write
+  athena: read
   s3_read_write:
     - alpha-cjs-scorecard/*
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Description

Adds athena read to the iam so as to allow the workflow to give the role the permissions to perform `athena:StartQueryExecution`


Fixes #(issue)

## Type of change

Please delete options that are not relevant.
- [ ] Update to existing role


## Additional Notes

