### PR TITLE
Change test to target prod tables

### DIFF
--- a/environments/development/analytical-platform/cadet-compile/workflow.yml
+++ b/environments/development/analytical-platform/cadet-compile/workflow.yml
@@ -4,9 +4,9 @@ dag:
   tag: v0.0.11
   compute_profile: general-spot-16vcpu-64gb
   env_vars:
-    DEPLOY_ENV: sandpit
+    DEPLOY_ENV: prod
     AWS_DEFAULT_REGION: eu-west-1
-    DBT_PROFILE_WORKGROUP: dbt-sandpit
+    DBT_PROFILE_WORKGROUP: dbt-prod
     DBT_PROJECT: mojap_derived_tables
     WORKFLOW_NAME: cadet-compile-airflow
     DBT_SELECT_CRITERIA: ./models/


### PR DESCRIPTION
## Description

Sandpit only has a tiny proportion of our data, so this will allow a more robust simulation of behaviour. This is still set to compile only, meaning that no tables will be deployed - only SQL models generated locally.

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)