### PR TITLE
🔀 Switch CaDeT to new repository 

### DIFF
--- a/environments/development/analytical-platform/cadet-compile/workflow.yml
+++ b/environments/development/analytical-platform/cadet-compile/workflow.yml
@@ -1,20 +1,19 @@
 ---
 dag:
-  repository: ministryofjustice/analytical-platform-cadet
-  tag: v0.1.4
+  repository: ministryofjustice/analytical-platform-airflow-cadet-deployer
+  tag: 1.0.0
   compute_profile: general-spot-16vcpu-64gb
   env_vars:
     DEPLOY_ENV: sandpit
-    AWS_DEFAULT_REGION: eu-west-1
     DBT_PROFILE_WORKGROUP: dbt-sandpit
     DBT_PROJECT: mojap_derived_tables
     WORKFLOW_NAME: cadet-compile-airflow
     DBT_SELECT_CRITERIA: models/development_sandpit
-    RETRY_TAGS: retry
     MODE: build
 
 maintainers:
   - jhpyke
+  - jacobwoffenden
 
 secrets:
   - github-key


### PR DESCRIPTION
## Proposed Changes

- Switches CaDeT to new repo https://github.com/ministryofjustice/analytical-platform-airflow-cadet-deployer

Signed-off-by: Jacob Woffenden <jacob.woffenden@justice.gov.uk>