### PR TITLE
Test CaDeT Build

### DIFF
--- a/environments/development/analytical-platform/cadet-compile/workflow.yml
+++ b/environments/development/analytical-platform/cadet-compile/workflow.yml
@@ -8,7 +8,7 @@ dag:
     DBT_PROFILE_WORKGROUP: dbt-sandpit
     DBT_PROJECT: mojap_derived_tables
     WORKFLOW_NAME: cadet-compile-airflow
-    DBT_SELECT_CRITERIA: models/general/
+    DBT_SELECT_CRITERIA: models/general/addressbase_stg
     BRANCH: test-airflow-aware-export
     MODE: build
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Description

Testing build mode as compile has special behaviour on fail compared to other modes. This will build non-sensitive data against sandpit, so no risk of spillage.


Fixes #(issue)

## Type of change

- [x] New feature (non-breaking change which adds functionality)
