### PR TITLE
Docs/running scripts locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,15 +31,22 @@ To ensure Python can resolve these imports, you must set the `PYTHONPATH` enviro
 2. Run a script using PYTHONPATH=airflow:
 
     ```bash
-    # validate schema
+    # to validate the source workflow schema
     PYTHONPATH=airflow uv run python scripts/workflow_schema_validation/main.py path/to/source/workflow.yml
 
-    # build it
+    # to build the dist workflow.yml
     PYTHONPATH=airflow uv run python scripts/workflow_generator/main.py path/to/source/workflow.yml
 
-    # validate it
+    # to validate the dist workflow.yml
     PYTHONPATH=airflow uv run python scripts/workflow_validation/main.py path/to/dist/workflow.yml
     ```
+
+### 📚 Why PYTHONPATH Is Needed
+
+The internal code is located under the airflow/ directory. Scripts use imports like:
+```python
+from analytical_platform.standard_operator import AnalyticalPlatformStandardOperator
+```
 
 Without setting PYTHONPATH=airflow, Python will not recognise analytical_platform as a valid module, since it's nested under the airflow/ directory.
 

--- a/README.md
+++ b/README.md
@@ -15,8 +15,7 @@ Commit signature verification is enabled on this repository. To set this up foll
 
 This project contains utility scripts under the `scripts/` directory that support DAG development and validation.
 
-These scripts import internal modules from the `airflow/analytical_platform` package.  
-To ensure Python can resolve these imports, you must set the `PYTHONPATH` environment variable when running the scripts locally.
+These scripts import internal modules from the `airflow/analytical_platform` package. To ensure Python can resolve these imports, you must set the `PYTHONPATH` environment variable when running the scripts locally.
 
 
 ### ✅ Quick Start

--- a/README.md
+++ b/README.md
@@ -44,9 +44,9 @@ These scripts import internal modules from the `airflow/analytical_platform` pac
 
 The internal code is located under the airflow/ directory. Scripts use imports like:
 
-    ```python
-    from analytical_platform.standard_operator import AnalyticalPlatformStandardOperator
-    ```
+```python
+from analytical_platform.standard_operator import AnalyticalPlatformStandardOperator
+```
 
 Without setting PYTHONPATH=airflow, Python will not recognise analytical_platform as a valid module, since it's nested under the airflow/ directory.
 

--- a/README.md
+++ b/README.md
@@ -9,3 +9,43 @@
 Please refer to our [User Guidance](https://user-guidance.analytical-platform.service.justice.gov.uk/services/airflow) for information on how to use Analytical Platform Airflow.
 
 Commit signature verification is enabled on this repository. To set this up follow the instructions [on GitHub](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#ssh-commit-signature-verification).
+
+
+## 🧪 Running Workflow Scripts Locally
+
+This project contains utility scripts under the `scripts/` directory that support DAG development and validation.
+
+These scripts import internal modules from the `airflow/analytical_platform` package.  
+To ensure Python can resolve these imports, you must set the `PYTHONPATH` environment variable when running the scripts locally.
+
+
+### ✅ Quick Start
+
+1. Install project dependencies using [`uv`](https://github.com/astral-sh/uv):
+
+    ```bash
+    uv venv
+    uv pip install -r requirements.txt
+    ```
+
+2. Run a script using PYTHONPATH=airflow:
+
+    ```bash
+    # validate schema
+    PYTHONPATH=airflow uv run python scripts/workflow_schema_validation/main.py path/to/source/workflow.yml
+
+    # build it
+    PYTHONPATH=airflow uv run python scripts/workflow_generator/main.py path/to/source/workflow.yml
+
+    # validate it
+    PYTHONPATH=airflow uv run python scripts/workflow_validation/main.py path/to/dist/workflow.yml
+    ```
+
+Without setting PYTHONPATH=airflow, Python will not recognise analytical_platform as a valid module, since it's nested under the airflow/ directory.
+
+
+### 🤖 Dev Containers and CI/CD
+
+In development containers and GitHub Actions workflows, PYTHONPATH=airflow is already set.
+
+You only need to configure this manually when running scripts directly on your local machine.

--- a/README.md
+++ b/README.md
@@ -43,9 +43,10 @@ These scripts import internal modules from the `airflow/analytical_platform` pac
 ### 📚 Why PYTHONPATH Is Needed
 
 The internal code is located under the airflow/ directory. Scripts use imports like:
-```python
-from analytical_platform.standard_operator import AnalyticalPlatformStandardOperator
-```
+
+    ```python
+    from analytical_platform.standard_operator import AnalyticalPlatformStandardOperator
+    ```
 
 Without setting PYTHONPATH=airflow, Python will not recognise analytical_platform as a valid module, since it's nested under the airflow/ directory.
 

--- a/README.md
+++ b/README.md
@@ -10,35 +10,33 @@ Please refer to our [User Guidance](https://user-guidance.analytical-platform.se
 
 Commit signature verification is enabled on this repository. To set this up follow the instructions [on GitHub](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#ssh-commit-signature-verification).
 
-
 ## 🧪 Running Workflow Scripts Locally
 
 This project contains utility scripts under the `scripts/` directory that support DAG development and validation.
 
 These scripts import internal modules from the `airflow/analytical_platform` package. To ensure Python can resolve these imports, you must set the `PYTHONPATH` environment variable when running the scripts locally.
 
-
 ### ✅ Quick Start
 
 1. Install project dependencies using [`uv`](https://github.com/astral-sh/uv):
 
-    ```bash
-    uv venv
-    uv pip install -r requirements.txt
-    ```
+   ```bash
+   uv venv
+   uv pip install -r requirements.txt
+   ```
 
 2. Run a script using PYTHONPATH=airflow:
 
-    ```bash
-    # to validate the source workflow schema
-    PYTHONPATH=airflow uv run python scripts/workflow_schema_validation/main.py path/to/source/workflow.yml
+   ```bash
+   # to validate the source workflow schema
+   PYTHONPATH=airflow uv run python scripts/workflow_schema_validation/main.py path/to/source/workflow.yml
 
-    # to build the dist workflow.yml
-    PYTHONPATH=airflow uv run python scripts/workflow_generator/main.py path/to/source/workflow.yml
+   # to build the dist workflow.yml
+   PYTHONPATH=airflow uv run python scripts/workflow_generator/main.py path/to/source/workflow.yml
 
-    # to validate the dist workflow.yml
-    PYTHONPATH=airflow uv run python scripts/workflow_validation/main.py path/to/dist/workflow.yml
-    ```
+   # to validate the dist workflow.yml
+   PYTHONPATH=airflow uv run python scripts/workflow_validation/main.py path/to/dist/workflow.yml
+   ```
 
 ### 📚 Why PYTHONPATH Is Needed
 
@@ -49,7 +47,6 @@ from analytical_platform.standard_operator import AnalyticalPlatformStandardOper
 ```
 
 Without setting PYTHONPATH=airflow, Python will not recognise analytical_platform as a valid module, since it's nested under the airflow/ directory.
-
 
 ### 🤖 Dev Containers and CI/CD
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Description

Add documentation for locally running the workflow scripts that run in CI. This should make it quicker/easier for users to build create workflows.

Fixes https://github.com/ministryofjustice/analytical-platform/issues/8193

## Type of change

Please delete options that are not relevant.

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Update to existing role
- [x] Documentation update

## Additional Notes

Add any other context or screenshots about the pull request here.
