### PR TITLE
Geog: Remove s3 from iam filepath

### DIFF
--- a/environments/development/geography/nspl-reference/workflow.yml
+++ b/environments/development/geography/nspl-reference/workflow.yml
@@ -50,7 +50,7 @@ iam:
   glue: true
   s3_read_write:
     - alpha-geography/dev/nspl_reference/*
-    
+
 maintainers:
   - p-sin
   - gwionap

--- a/environments/development/geography/nspl-reference/workflow.yml
+++ b/environments/development/geography/nspl-reference/workflow.yml
@@ -49,7 +49,7 @@ iam:
   athena: write
   glue: true
   s3_read_write:
-    - s3://alpha-geography/dev/nspl_reference/*
+    - alpha-geography/dev/nspl_reference/*
 
 maintainers:
   - p-sin


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Description

Remove the s3 prefix from the iam policy file path!

## Type of change

- [X] Bugfix (non-breaking change which fixes an issue)
