### PR TITLE
fix: env vars for orchestration

### DIFF
--- a/environments/test/hmcts/x-cjs-load-postcharge/workflow.yml
+++ b/environments/test/hmcts/x-cjs-load-postcharge/workflow.yml
@@ -10,8 +10,18 @@ dag:
   schedule: None
 
   env_vars:
-    LOG_LEVEL: "DEBUG"
-    SERVICE: "load_postcharge"
+      LOG_LEVEL: "DEBUG"
+      ENV: "test"
+      FULL_REFRESH: "false"
+      S3_LAND_DELETION_FLAG: "false"
+      SCRIPT_ENTRYPOINT: src/pipeline.py
+
+  tasks:
+    load_postcharge:
+      env_vars:
+        SERVICE: "load_postcharge"
+    
+    # add other tasks here.
 
 notifications:
   emails:


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Description

Trying to pass env variables to the dag which match how the pipeline is ran locally and in docker.

Fixes #(issue)

- [x] Bugfix (non-breaking change which fixes an issue)