### PR TITLE
Add bucket permissions

### DIFF
--- a/environments/test/hmcts/x-cjs-load-postcharge/workflow.yml
+++ b/environments/test/hmcts/x-cjs-load-postcharge/workflow.yml
@@ -34,6 +34,7 @@ iam:
     - mojap-land-dev/cps/testing/*
     - mojap-raw-hist-dev/crown_prosecution_service/testing/*
     - alpha-cjs-dataset-sensitive-dip/testing/*
+    - alpha-criminal-courts-data-staging/crown_prosecution_service/*
 
 maintainers:
   - parminder-thindal-moj


### PR DESCRIPTION
Add bucket permission for s3://alpha-criminal-courts-data-staging/crown_prosecution_service/

<!-- markdownlint-disable MD041 -->

## Description

Provide access to write area in S3 bucket.

- [x] Bugfix (non-breaking change which fixes an issue)

