### PR TITLE
production workflow configuration for scram

### DIFF
--- a/environments/production/electronic-monitoring-data-store/load-scram-alcohol-monitoring/workflow.yml
+++ b/environments/production/electronic-monitoring-data-store/load-scram-alcohol-monitoring/workflow.yml
@@ -1,0 +1,48 @@
+dag:
+  repository: moj-analytical-services/airflow-load-em-data
+  tag: v0.2.62
+  compute_profile: general-spot-1vcpu-4gb
+  catchup: false
+  depends_on_past: false
+  max_active_runs: 1
+  env_vars:
+    SUPPLIER_NAME: "scram"
+    SYSTEM_NAME: "alcohol_monitoring"
+    DATASET_NAME: "scram_alcohol_monitoring"
+    DELIVERY_DATE: "2025-05-21"
+    AWS_METADATA_SERVICE_TIMEOUT: 60
+    AWS_METADATA_SERVICE_NUM_ATTEMPTS: 5
+    AWS_DEFAULT_REGION: "eu-west-2"
+    AWS_ATHENA_QUERY_EXTRACT_REGION: "eu-west-2"
+    AWS_DEFAULT_EXTRACT_REGION: "eu-west-2"
+
+  tasks:
+    load_scram_alerts:
+      env_vars:
+        TABLE_NAME: "Alerts"
+
+    load_scram_clients:
+      env_vars:
+        TABLE_NAME: "Clients"
+
+    load_scram_readings:
+      env_vars:
+        TABLE_NAME: "Readings"
+
+notifications:
+  emails:
+    - Matt.Heery@justice.gov.uk
+    - Luke.Williams6@justice.gov.uk
+  slack_channel: em-engineers-moj-madetech
+
+iam:
+  external_role: arn:aws:iam::976799291502:role/airflow-prod-load-scram-alcohol-monitoring
+
+maintainers:
+  - matt-heery
+  - kraihanmoj
+  - luke-a-williams
+
+tags:
+  business_unit: HMPPS
+  owner: matt.heery@justice.gov.uk # for now....


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Description

New airflow job to load the SCRAM Alcohol Monitoring Database into production ready for consumption by DBT. Depends heavily on the Delivery Date parameter as there are broken files in other buckets, but this bucket has been determined to be the latest, fixed, data.

Fixes #(ELM-3665)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Additional Notes

Ticket: [ELM-3665](https://dsdmoj.atlassian.net/browse/ELM-3665)
Other Relevant PRs in other repos:
- DLT Code: [airflow-load-em-data](https://github.com/moj-analytical-services/airflow-load-em-data/pull/223)
- Terraform: [modernisation-platform-environments](https://github.com/ministryofjustice/modernisation-platform-environments/pull/12530)


[ELM-3665]: https://dsdmoj.atlassian.net/browse/ELM-3665?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ