### PR TITLE
reverting alpha release

### DIFF
--- a/environments/test/electronic-monitoring-data-store/load-scram-alcohol-monitoring/workflow.yml
+++ b/environments/test/electronic-monitoring-data-store/load-scram-alcohol-monitoring/workflow.yml
@@ -1,6 +1,6 @@
 dag:
   repository: moj-analytical-services/airflow-load-em-data
-  tag: v0.2.64-alpha
+  tag: v0.2.62
   compute_profile: general-spot-1vcpu-4gb
   catchup: false
   depends_on_past: false


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Description

Reverting the tag back to original due to problems in the airflow run and debugging where it's source might be.

Fixes #(issue)

## Type of change

Please delete options that are not relevant.

- [x] Bugfix (non-breaking change which fixes an issue)

## Additional Notes
