### PR TITLE
OPG: Bump sirius prod to 3.5.14

### DIFF
--- a/environments/production/opg/sirius-daily/workflow.yml
+++ b/environments/production/opg/sirius-daily/workflow.yml
@@ -1,6 +1,6 @@
 dag:
   repository: moj-analytical-services/airflow-opg-etl
-  tag: v3.5.7
+  tag: v3.5.14
   catchup: false
   depends_on_past: false
   is_paused_upon_creation: false
@@ -13,7 +13,7 @@ dag:
     DATABASE: "sirius"
     PIPELINE_NAME: "sirius"
     DATABASE_VERSION: "prod"
-    GITHUB_TAG: "v3.5.7"
+    GITHUB_TAG: "v3.5.14"
     ATHENA_DB_PREFIX: "opg"
     START_DATE: "2025-06-17"
     AWS_DEFAULT_REGION: "eu-west-1"


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Description

Bump OPG Sirius to use 3.5.14 in prod.

## Type of change

- [X] Bugfix (non-breaking change which fixes an issue)