### PR TITLE
Common platform prod test

### DIFF
--- a/environments/production/hmcts/common-platform/workflow.yml
+++ b/environments/production/hmcts/common-platform/workflow.yml
@@ -15,11 +15,11 @@ dag:
     CHECK_MODE: "hist"
     FILENAME_COL_NAME: "mojap_unpacked_filename"
     EXCLUDED_FILES_REGEXPR: "_metadata.json$"
-    DATABASE_NAME: "common_platform_dev_v4"
+    DATABASE_NAME: "common_platform_dev_v5"
     LAND_BUCKET: "s3://mojap-land-dev"
     HIST_BUCKET: "s3://mojap-raw-hist-dev"
-    LAND_FOLDER: "hmcts/common-platform/dev/dev_sdp_v4"
-    HIST_FOLDER: "hmcts/common-platform/dev/dev_sdp_v4"
+    LAND_FOLDER: "hmcts/common-platform/dev/dev_sdp_v5"
+    HIST_FOLDER: "hmcts/common-platform/dev/dev_sdp_v5"
     CUT_OFF: "2022-08-21"
   tasks:
     cp_extract_allocated_listings:


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Description

Add new Common-platform extraction DAG to Production environment. Primary purpose is to test new SDP connection credentials before distributing to all HMCTS SDP DAGs. Test environment does not currently have a connection to the SDP.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)



