### PR TITLE
:wrench: Use `gh` > `curl` in Workflow Validation Action

### DIFF
--- a/.github/workflows/workflow-validation.yml
+++ b/.github/workflows/workflow-validation.yml
@@ -368,7 +368,7 @@ jobs:
           imageRepo=${imageName#ghcr.io/}
           echo "upstream-image-repo=${imageRepo}" >>"${GITHUB_ENV}"
 
-          imageRepoLatestVersion=$(curl --silent https://api.github.com/repos/"${imageRepo}"/releases/latest | jq -r '.tag_name')
+          imageRepoLatestVersion=$(gh api "repos/${imageRepo}/releases/latest" --jq '.tag_name' 2>/dev/null || echo "")
           export imageRepoLatestVersion
           echo "upstream-image-version=${imageRepoLatestVersion}" >>"${GITHUB_ENV}"
 

--- a/environments/development/analytical-platform/example/workflow.yml
+++ b/environments/development/analytical-platform/example/workflow.yml
@@ -19,6 +19,7 @@ iam:
 maintainers:
   - jacobwoffenden
   - jhpyke
+  - gary-h9
 
 secrets:
   - api-key

--- a/environments/development/analytical-platform/example/workflow.yml
+++ b/environments/development/analytical-platform/example/workflow.yml
@@ -19,7 +19,6 @@ iam:
 maintainers:
   - jacobwoffenden
   - jhpyke
-  - gary-h9
 
 secrets:
   - api-key


### PR DESCRIPTION
This PR relates to [this](https://github.com/orgs/ministryofjustice/projects/27/views/18?pane=issue&itemId=120785833&issue=ministryofjustice%7Canalytical-platform%7C8151) piece of work. 

- Switches set up actions to use gh when downloading assets from GitHub
- We are seeing potential rate limiting when using cURL and unauthenticated requests

🧪  Tested by altering an example workflow then reverting, you can see the comments in this PR. 