### PR TITLE
OPG: Bump ocr to 3.6.1

### DIFF
--- a/environments/development/opg/ocr/workflow.yml
+++ b/environments/development/opg/ocr/workflow.yml
@@ -1,6 +1,6 @@
 dag:
   repository: moj-analytical-services/airflow-opg-etl
-  tag: v3.6.0
+  tag: v3.6.1
   catchup: false
   depends_on_past: false
   is_paused_upon_creation: false


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Description

Bump OPG OCR to 3.6.1

## Type of change

- [X] Bugfix (non-breaking change which fixes an issue)