### PR TITLE
Up compute_profile to 2vcpu 8gb as proc was OOM

### DIFF
--- a/environments/production/ccmbpt/deep-dive-models/workflow.yml
+++ b/environments/production/ccmbpt/deep-dive-models/workflow.yml
@@ -4,6 +4,7 @@ dag:
   retries: 3
   retry_delay: 150
   schedule: "0 8 * * 1-5"
+  compute_profile: general-on-demand-2vcpu-8gb
 
 maintainers:
   - chrisbanbury


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Description

Running out of resources so changed from 4gb to 8gb

## Type of change

Please delete options that are not relevant.

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Update to existing role
- [ ] Documentation update

## Additional Notes

