### PR TITLE
Up compute profile for ccmbpt-deep-dive-models

### DIFF
--- a/environments/production/ccmbpt/deep-dive-models/workflow.yml
+++ b/environments/production/ccmbpt/deep-dive-models/workflow.yml
@@ -4,7 +4,7 @@ dag:
   retries: 3
   retry_delay: 150
   schedule: "0 8 * * 1-5"
-  compute_profile: general-on-demand-2vcpu-8gb
+  compute_profile: general-on-demand-4vcpu-16gb
 
 maintainers:
   - chrisbanbury


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Description

Using general-on-demand-4vcpu-16gb as we're still getting OOM'd

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Update to existing role
- [ ] Documentation update

## Additional Notes

