### PR TITLE
OPG: Bump OCR version and add new s3 permission

### DIFF
--- a/environments/development/opg/ocr/workflow.yml
+++ b/environments/development/opg/ocr/workflow.yml
@@ -1,6 +1,6 @@
 dag:
   repository: moj-analytical-services/airflow-opg-etl
-  tag: v3.6.16
+  tag: v3.6.17
   catchup: false
   depends_on_past: false
   is_paused_upon_creation: false
@@ -35,6 +35,7 @@ iam:
   glue: true
   s3_read_write:
     - mojap-land/opg/dev/ocr/*
+    - mojap-raw/opg/dev/ocr/*
     - mojap-raw-hist/opg/dev/ocr/*
     - mojap-processed/opg/dev/ocr/*
     - alpha-opg-etl/dev/ocr/*


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Description

Bump OCR to 3.6.17 and add a new s3 permission

## Type of change

- [X] Bugfix (non-breaking change which fixes an issue)
