### PR TITLE
feat: bump version image to `v1.0.1`

### DIFF
--- a/environments/production/hmcts/xcjs-extract-load/workflow.yml
+++ b/environments/production/hmcts/xcjs-extract-load/workflow.yml
@@ -2,7 +2,7 @@
 # https://user-guidance.analytical-platform.service.justice.gov.uk/services/airflow/index.html
 dag:
   repository: moj-analytical-services/airflow-cross-cjs-data
-  tag: v1.0.0
+  tag: v1.0.1
   catchup: false
   compute_profile: "general-spot-8vcpu-32gb"
   depends_on_past: false


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Description

Bumps the image version to 1.0.1, changing the data contract from freeze to flexible to get around a bug in Athena.

- [x] Bugfix (non-breaking change which fixes an issue)

