### PR TITLE
🛠️  Fix schedule error with null in workflow_generator

### DIFF
--- a/scripts/workflow_generator/templates/workflow.yml.j2
+++ b/scripts/workflow_generator/templates/workflow.yml.j2
@@ -40,7 +40,7 @@
     {{ k }}: "{{ v }}"
     {%- endfor %}
   {%- endif %}
-  schedule: {{ dag.schedule|default(null) }}
+  schedule: {{ dag.schedule|default("None") }}
   tasks:
     {%- if dag.tasks %}
     {%- for task_name, task in dag.tasks.items() %}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Description
 This PR fixes a bug with schedule in the workflow_generator. In the new version of dagfactory, "null" is being parsed as 0:00AM daily. Changed default to None

https://github.com/ministryofjustice/analytical-platform/issues/8520

## Type of change

Please delete options that are not relevant.

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Update to existing role
- [ ] Documentation update

## Additional Notes

Add any other context or screenshots about the pull request here.
