### PR TITLE
🛠️ Add Dataset inlets and outlets to workflow schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,5 +98,5 @@ Without setting `PYTHONPATH=airflow`, Python will not recognise [`analytical_pla
 
 1. Log in to Airflow <http://localhost:8080>
 
-- Username: airflow
+- Username: admin
 - Password: test

--- a/environments/development/analytical-platform/example-dataset-schedule/workflow.yml
+++ b/environments/development/analytical-platform/example-dataset-schedule/workflow.yml
@@ -1,0 +1,23 @@
+---
+dag:
+  repository: moj-analytical-services/analytical-platform-airflow-python-example
+  tag: 2.14.0
+  retries: 3
+  retry_delay: 150
+  schedule:
+    datasets:
+      - "s3://ap_bucket/this_is_a_test_dataset.json"
+  tasks:
+    task_one:
+      env_vars:
+        TASK: "SECOND"
+
+notifications:
+  slack_channel: analytical-platform-airflow-testing
+
+maintainers:
+  - antfmoj
+
+tags:
+  business_unit: Central Digital
+  owner: analytical-platform@justice.gov.uk

--- a/environments/development/analytical-platform/example-outlet/workflow.yml
+++ b/environments/development/analytical-platform/example-outlet/workflow.yml
@@ -1,0 +1,22 @@
+---
+dag:
+  repository: moj-analytical-services/analytical-platform-airflow-python-example
+  tag: 2.14.0
+  retries: 3
+  retry_delay: 150
+  tasks:
+    task_one:
+      outlets:
+        - "s3://ap_bucket/this_is_a_test_dataset.json"
+      env_vars:
+        TASK: "FIRST"
+
+notifications:
+  slack_channel: analytical-platform-airflow-testing
+
+maintainers:
+  - antfmoj
+
+tags:
+  business_unit: Central Digital
+  owner: analytical-platform@justice.gov.uk

--- a/scripts/workflow_generator/templates/workflow.yml.j2
+++ b/scripts/workflow_generator/templates/workflow.yml.j2
@@ -72,6 +72,12 @@
       {%- if task.dependencies %}
       dependencies: {{ task.dependencies }}
       {%- endif %}
+      {%- if task.inlets %}
+      inlets: {{ task.inlets }}
+      {%- endif %}
+      {%- if task.outlets %}
+      outlets: {{ task.outlets }}
+      {%- endif %}
     {%- endfor %}
     {%- else %}
     main:

--- a/scripts/workflow_schema_validation/schema.json
+++ b/scripts/workflow_schema_validation/schema.json
@@ -62,7 +62,7 @@
       "max_active_runs": { "type": "integer", "required": false },
       "retries": { "type": "integer", "required": false },
       "retry_delay": { "type": "integer", "required": false },
-      "schedule": { "type": "string", "required": false },
+      "schedule": { "type": ["string", "list", "dict"], "required": false },
       "start_date": { "type": "string", "required": false },
       "tasks": {
         "type": "dict",
@@ -119,6 +119,16 @@
               "required": false
             },
             "dependencies": {
+              "type": "list",
+              "schema": { "type": "string" },
+              "required": false
+            },
+            "inlets": {
+              "type": "list",
+              "schema": { "type": "string" },
+              "required": false
+            },
+            "outlets": {
               "type": "list",
               "schema": { "type": "string" },
               "required": false


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Description

This pull request completes https://github.com/ministryofjustice/analytical-platform/issues/8150
Workflow schema is updated to include inlets and outlets.
A new example workflow is created to test outlets. A second PR will be created to test schedule using the dataset.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Additional Notes

This pull request shows what changes are needed to enable data-driven scheduling.