### PR TITLE
Update and rename regime-dashboard workflow.yml

### DIFF
--- a/environments/development/ppt/regime-dashboard/workflow.yml
+++ b/environments/development/ppt/regime-dashboard/workflow.yml
@@ -1,6 +1,8 @@
 dag:
   repository: moj-analytical-services/airflow_regime_dashboard_data
   tag: v.0.1.41
+  retries: 3
+  retry_delay: 150
   schedule: "00 14 * * 2"
   compute_profile: general-spot-2vcpu-8gb
 


### PR DESCRIPTION
Rename regime-dashboard workflow.yml folder and set 3 retries

<!-- markdownlint-disable MD041 -->

## Description

Rename the regime-dashboard workflow.yml folder to be consistent with other Prison Performance Team products, and set the number of retries to 3.
