### PR TITLE
OPG: Configure sirius as 'prod'

### DIFF
--- a/environments/production/opg/sirius-monthly/dag.py
+++ b/environments/production/opg/sirius-monthly/dag.py
@@ -32,7 +32,7 @@ dag = DAG(
 base_env_vars={
     "DATABASE": "sirius",
     "PIPELINE_NAME": f"{WORKFLOW}",
-    "DATABASE_VERSION": "dev",
+    "DATABASE_VERSION": "prod",
     "GITHUB_TAG": f"{REPOSITORY_TAG}",
     "ATHENA_DB_PREFIX": "opg",
     "START_DATE": start_date.strftime("%Y-%m-%d"),

--- a/environments/production/opg/sirius-monthly/workflow.yml
+++ b/environments/production/opg/sirius-monthly/workflow.yml
@@ -1,7 +1,7 @@
 ---
 dag:
   repository: moj-analytical-services/airflow-opg-etl
-  tag: v3.5.5
+  tag: v3.5.20
   python_dag: true
 
 iam:

--- a/environments/production/opg/sirius-monthly/workflow.yml
+++ b/environments/production/opg/sirius-monthly/workflow.yml
@@ -1,7 +1,7 @@
 ---
 dag:
   repository: moj-analytical-services/airflow-opg-etl
-  tag: v3.5.19
+  tag: v3.5.5
   python_dag: true
 
 iam:


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Description

Set the prod pipeline to use 'prod' variable and not 'dev'

## Type of change

- [X] Bugfix (non-breaking change which fixes an issue)
