### PR TITLE
prisons-de - add lake formation permission

### DIFF
--- a/environments/development/prison-intel-dsai/bentham/workflow.yml
+++ b/environments/development/prison-intel-dsai/bentham/workflow.yml
@@ -39,7 +39,7 @@ notifications:
   slack_channel: intel-app-maintenance
 
 maintainers:
-  - mattfunnell
+  - MattFunnell
   - d-lundie
 
 tags:

--- a/environments/development/prison-intel-dsai/bentham/workflow.yml
+++ b/environments/development/prison-intel-dsai/bentham/workflow.yml
@@ -16,6 +16,8 @@ dag:
 iam:
   athena: write
 
+  lake_formation: true
+
   s3_read_only:
     - alpha-app-kpi-s3-proxy/*
     - mojap-derived-tables/prod/models/domain_name=prison/database_name=nomis_dbt/*


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Description

To give a prisons data science workflow lake formation permission.  Will work alongside permissions made in [this PR](https://github.com/moj-analytical-services/data-engineering-datalake-access/pull/330)
Fixes #(issue)

## Type of change

- [X] New feature (non-breaking change which adds functionality)

## Additional Notes

@MattFunnell - for info