### PR TITLE
Remove aquasecurity/trivy-action from .github/workflows/workflow-validation.yml

### DIFF
--- a/.github/workflows/workflow-validation.yml
+++ b/.github/workflows/workflow-validation.yml
@@ -511,20 +511,7 @@ jobs:
 
       - name: Scan
         id: scan
-        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
-        env:
-          TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db:2
-          TRIVY_JAVA_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-java-db:1
-        with:
-          image-ref: 509399598587.dkr.ecr.eu-west-2.amazonaws.com/${{ env.ecr-repository }}:${{ env.image-tag }}
-          severity: HIGH,CRITICAL
-          ignore-unfixed: true
-          skip-dirs: "/home/analyticalplatform/.cache/R,/usr/local/lib/R/site-library/openssl/doc"
-          timeout: 10m0s
-          exit-code: 1
-          vuln-type: "library"
-          version: "v0.69.2"
-
+        run: exit 0 # trivy-action step removed
       - name: Comment on Scan Failure
         id: comment_on_scan_failure
         if: failure() && steps.scan.outcome == 'failure'


### PR DESCRIPTION
## Why

`aquasecurity/trivy-action` has been compromised for the second time. All tags before `0.35.0` were re-pointed to a malicious commit that **dumps process memory to steal credentials** from CI runners.

- **Issue:** https://github.com/aquasecurity/trivy-action/issues/541
- **Exposure window (UTC):** 2026-03-19 ~17:43 – 2026-03-20 ~05:40
- **Malicious commit:** `aquasecurity/setup-trivy@8afa9b9`
- **Details:** https://www.stepsecurity.io/blog/trivy-compromised-a-second-time---malicious-v0-69-4-release

As [recommended by the maintainers](https://github.com/aquasecurity/trivy-action/issues/541#issuecomment-2737987938):

> "As hard as it may be: do not use Trivy anymore for now."

Any repository that ran a workflow using this action during the exposure window may have had secrets exfiltrated. **Rotate any secrets that were available to workflows using this action.**

## What this PR does

Removes the `aquasecurity/trivy-action` step(s) from this workflow. The `uses:` directive and its `with:` block have been replaced with a `run:` step that creates an empty but valid SARIF file (where applicable), so downstream steps (e.g. `upload-sarif`) continue to pass.

> **Note:** Repo owners should review whether the entire workflow/job can now be removed, or whether an alternative scanning solution should be adopted.

Raised automatically for review.
