### PR TITLE
Add `R_CONFIG_ACTIVE` to new workflow

### DIFF
--- a/environments/production/bold-rr-cid/offender/workflow.yml
+++ b/environments/production/bold-rr-cid/offender/workflow.yml
@@ -5,6 +5,7 @@ dag:
   schedule: "0 6 * * *"
 
   env_vars:
+    R_CONFIG_ACTIVE: "case_info_dashboard"
     CASE_INFO_DASHBOARD_TESTING: "no"
 
   tasks:


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Description

This is to have `offendeR` write the CID tables to the specified DB, not the temp one. In fact, `R_CONFIG_ACTIVE` was defined in the [old DAG](https://github.com/moj-analytical-services/airflow/blob/main/environments/prod/dags/offender/case_info_dashboard.py#L48), but not in the new. In the new DAG, with `R_CONFIG_ACTIVE` undefined, it is reverting back to temp tables.

## Type of change

Please delete options that are not relevant.

- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
## Additional Notes

https://mojdt.slack.com/archives/D06L7HRPK6Y/p1775728705732169 (Only @guyvw1 and I can access this, so I'm adding him as reviewer.)
