### PR TITLE
bump to image version to include time zone awareness for date fields

### DIFF
--- a/environments/production/hmcts/libra-load/workflow.yml
+++ b/environments/production/hmcts/libra-load/workflow.yml
@@ -1,6 +1,6 @@
 dag:
   repository: moj-analytical-services/airflow-create-a-pipeline
-  tag: v4.0.7
+  tag: v4.0.12
   retries: 1
   retry_delay: 150
   start_date: "2026-01-10"
@@ -478,6 +478,9 @@ iam:
     - mojap-land/hmcts/libra/*
     - mojap-raw-hist/hmcts/libra/*
     - alpha-mojap-curated-libra/prod/v1/*
+
+notifications:
+  slack_channel: dmet-hmcts-notifications
 
 maintainers:
   - jovita-brundziene

--- a/environments/production/hmcts/xhibit-load/workflow.yml
+++ b/environments/production/hmcts/xhibit-load/workflow.yml
@@ -1,6 +1,6 @@
 dag:
   repository: moj-analytical-services/airflow-create-a-pipeline
-  tag: v4.0.3
+  tag: v4.0.12
   retries: 1
   retry_delay: 150
   start_date: "2025-12-22"


### PR DESCRIPTION
…- due to HMCTS change in oracle connector

<!-- markdownlint-disable MD041 -->

## Description

Bumping image versions of these DAGs to include timezone awareness when casting date fields. Plus slack notifications.


## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)
