### PR TITLE
Updated cadet-corp-epm to new version

### DIFF
--- a/environments/production/analytical-platform/cadet-corp-epm/workflow.yml
+++ b/environments/production/analytical-platform/cadet-corp-epm/workflow.yml
@@ -1,15 +1,17 @@
 ---
 dag:
   repository: ministryofjustice/analytical-platform-airflow-cadet-deployer
-  tag: 1.2.2
+  tag: 1.3.1
   schedule: "30 00 * * *"
   catchup: false
+  is_paused_upon_creation: true
   env_vars:
     DEPLOY_ENV: prod
     DBT_PROFILE_WORKGROUP: dbt-daily
     DBT_PROJECT: mojap_derived_tables
     WORKFLOW_NAME: deploy-corporate-epm
     DBT_SELECT_CRITERIA: tag:corporate_epm
+    THREAD_COUNT: 10
     BRANCH: main
     MODE: build
   tasks:


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

This pull request updates the workflow configuration for the `cadet-corp-epm` deployment in the production environment. 

Key changes:

**Deployment and Scheduling:**
* Updated the `dag.repository` image tag from `1.2.2` to `1.3.1`
* Set `is_paused_upon_creation: true`

**Environment Variables:**
* Added `THREAD_COUNT: 10` to the environment variables
