### PR TITLE
Update cadet-corp-epm version

### DIFF
--- a/environments/production/analytical-platform/cadet-corp-epm/workflow.yml
+++ b/environments/production/analytical-platform/cadet-corp-epm/workflow.yml
@@ -1,15 +1,17 @@
 ---
 dag:
   repository: ministryofjustice/analytical-platform-airflow-cadet-deployer
-  tag: 1.2.2
+  tag: 1.3.1
   schedule: "30 00 * * *"
   catchup: false
+  is_paused_upon_creation: true
   env_vars:
     DEPLOY_ENV: prod
     DBT_PROFILE_WORKGROUP: dbt-daily
     DBT_PROJECT: mojap_derived_tables
     WORKFLOW_NAME: deploy-corporate-epm
     DBT_SELECT_CRITERIA: tag:corporate_epm
+    THREAD_COUNT: 10
     BRANCH: main
     MODE: build
   tasks:


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

This pull request updates the Airflow workflow configuration for the Cadet Corporate EPM deployment. The main changes include updating the deployed tag version, adding new environment variables, and modifying workflow behavior.

Workflow configuration updates:

* Updated the `dag` to use tag `1.3.1` instead of `1.2.2` for the `ministryofjustice/analytical-platform-airflow-cadet-deployer` repository
* Added the `THREAD_COUNT` environment variable set to `10`
* Set `is_paused_upon_creation: true`
