### PR TITLE
Update tag to v.0.4.0

### DIFF
--- a/environments/development/ppt/regime-dashboard/workflow.yml
+++ b/environments/development/ppt/regime-dashboard/workflow.yml
@@ -1,6 +1,6 @@
 dag:
   repository: moj-analytical-services/airflow_regime_dashboard_data
-  tag: v.0.3.6
+  tag: v.0.4.0
   retries: 3
   retry_delay: 150
   schedule: "00 14 * * *"


### PR DESCRIPTION
Update image tag from v.0.3.6 to v.0.4.0

<!-- markdownlint-disable MD041 -->

## Description

- Update GitHub Actions and R Base, as per [this announcement](https://mojdt.slack.com/archives/C4PF7QAJZ/p1777551746672789).
- Updates to R packages.
- Align population in CU172(i) with CU172(ii) for 2026/27.
- Get activity categories from the course_activities table for 2026/27.