### PR TITLE
adding athena write and glue permissions

### DIFF
--- a/environments/test/sa26-rep/test/workflow.yml
+++ b/environments/test/sa26-rep/test/workflow.yml
@@ -7,7 +7,8 @@ dag:
   max_active_runs: 1
 
 iam:
-  athena: read
+  athena: write
+  glue: true
   s3_read_only:
     - mojap-derived-tables/prod/models/domain_name=probation/database_name=delius/*
     - mojap-derived-tables/prod/models/domain_name=probation/database_name=derived_delius/*


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Description

adding athena write and glue permissions to allow writing to sa26_monitoring db, and ensure temp tables can be created. 

The airflow run is currently failing with "Error: FAILED: Execution Error, return code 1 from org.apache.hadoop.hive.ql.exec.DDLTask. MetaException(message:User: arn:aws:sts::593291632749:assumed-role/airflow-test-sa26-rep-test/airflow-test-sa26-rep-test_1778652064.43922 is not authorized to perform: glue:CreateDatabase on resource: arn:aws:glue:eu-west-1:593291632749:catalog because no identity-based policy allows the glue:CreateDatabase action". 

Fixes #(issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Additional Notes

Add any other context or screenshots about the pull request here.
