### PR TITLE
Update tag to v.0.4.2

### DIFF
--- a/environments/development/ppt/regime-dashboard/workflow.yml
+++ b/environments/development/ppt/regime-dashboard/workflow.yml
@@ -1,6 +1,6 @@
 dag:
   repository: moj-analytical-services/airflow_regime_dashboard_data
-  tag: v.0.4.1
+  tag: v.0.4.2
   retries: 3
   retry_delay: 150
   schedule: "00 14 * * *"


### PR DESCRIPTION
Update tag from v.0.4.1 to v.0.4.2

<!-- markdownlint-disable MD041 -->

## Description

- Add option to export the output files to the HMPPS Performance Hub.
- Temporarily amend run date for CU172(i) to the 13th calendar day of the month.