### PR TITLE
Update tag to v.0.4.3

### DIFF
--- a/environments/development/ppt/regime-dashboard/workflow.yml
+++ b/environments/development/ppt/regime-dashboard/workflow.yml
@@ -1,6 +1,6 @@
 dag:
   repository: moj-analytical-services/airflow_regime_dashboard_data
-  tag: v.0.4.2
+  tag: v.0.4.3
   retries: 3
   retry_delay: 150
   schedule: "00 14 * * *"


### PR DESCRIPTION
Update tag from v.0.4.2 to v.0.4.3

<!-- markdownlint-disable MD041 -->

## Description

Run CU172(i) on the 16th calendar day of each month and export the output files to the HMPPS Performance Hub.