### PR TITLE
Add maintainers to psog-report dev workflow

### DIFF
--- a/environments/development/probation/psog-report/workflow.yml
+++ b/environments/development/probation/psog-report/workflow.yml
@@ -19,11 +19,15 @@ iam:
 maintainers:
   - lalithanagarur
   - AntonyJScott
+  - joephillipsjustice
+  - AntFMoJ
 
 notifications:
   emails:
     - lalitha.nagarur3@justice.gov.uk
     - antony.scott@justice.gov.uk
+    - joseph.phillips@justice.gov.uk
+    - anthony.fitzroy@justice.gov.uk
 
 tags:
   business_unit: HMPPS

--- a/environments/development/probation/psog-report/workflow.yml
+++ b/environments/development/probation/psog-report/workflow.yml
@@ -28,6 +28,7 @@ notifications:
     - antony.scott@justice.gov.uk
     - joseph.phillips@justice.gov.uk
     - anthony.fitzroy@justice.gov.uk
+  slack_channel: de-probation-airflow-dev
 
 tags:
   business_unit: HMPPS


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Description
This pull request updates the maintainers and notification settings in the `psog-report` workflow configuration to reflect the current team members and improve communication.

Team and notification updates:

* Added `joephillipsjustice` and `AntFMoJ` as maintainers in the `workflow.yml` file.
* Added `joseph.phillips@justice.gov.uk` and `anthony.fitzroy@justice.gov.uk` to the notification email list.
* Added a Slack channel notification (`de-probation-airflow-dev`) for workflow events.