### PR TITLE
Add slack notifications and maintainers to prod psog-report workflow

### DIFF
--- a/environments/production/probation/psog-report/workflow.yml
+++ b/environments/production/probation/psog-report/workflow.yml
@@ -22,6 +22,8 @@ iam:
 maintainers:
   - lalithanagarur
   - AntonyJScott
+  - joephillipsjustice
+  - AntFMoJ
 
 notifications:
   emails:

--- a/environments/production/probation/psog-report/workflow.yml
+++ b/environments/production/probation/psog-report/workflow.yml
@@ -27,6 +27,9 @@ notifications:
   emails:
     - lalitha.nagarur3@justice.gov.uk
     - antony.scott@justice.gov.uk
+    - joseph.phillips@justice.gov.uk
+    - anthony.fitzroy@justice.gov.uk
+  slack_channel: de-probation-airflow-prod
 
 tags:
   business_unit: HMPPS


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Description
This pull request makes a minor update to the `psog-report` workflow configuration by adding new maintainers and notification recipients.

- **Maintainers and Notifications Update:**
  * Added `joephillipsjustice` and `AntFMoJ` to the list of maintainers.
  * Added `joseph.phillips@justice.gov.uk` and `anthony.fitzroy@justice.gov.uk` to the notification emails and set a Slack channel for notifications.