### PR TITLE
Add maintainers to dev appointment-reminders workflow

### DIFF
--- a/environments/development/probation/appointment-reminders/workflow.yml
+++ b/environments/development/probation/appointment-reminders/workflow.yml
@@ -92,11 +92,15 @@ iam:
 maintainers:
   - AntonyJScott
   - lalithanagarur
+  - joephillipsjustice
+  - AntFMoJ
 
 notifications:
   emails:
     - lalitha.nagarur3@justice.gov.uk
     - antony.scott@justice.gov.uk
+    - joseph.phillips@justice.gov.uk
+    - anthony.fitzroy@justice.gov.uk
   slack_channel: de-probation-airflow-dev
 
 tags:


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Description

This pull request updates the maintainers and notification emails for the `probation/appointment-reminders` workflow in the development environment. The changes ensure the correct team members are listed for maintenance and notifications.

Team updates:

* Added `joephillipsjustice` and `AntFMoJ` to the `maintainers` list in `workflow.yml` to reflect current maintainers.

Notification updates:

* Added `joseph.phillips@justice.gov.uk` and `anthony.fitzroy@justice.gov.uk` to the notification emails to ensure all relevant team members receive updates.
