### PR TITLE
Add maintainers to prod appointment-reminders workflow

### DIFF
--- a/environments/production/probation/appointment-reminders/workflow.yml
+++ b/environments/production/probation/appointment-reminders/workflow.yml
@@ -95,11 +95,15 @@ iam:
 maintainers:
   - AntonyJScott
   - lalithanagarur
+  - joephillipsjustice
+  - AntFMoJ
 
 notifications:
   emails:
     - lalitha.nagarur3@justice.gov.uk
     - antony.scott@justice.gov.uk
+    - joseph.phillips@justice.gov.uk
+    - anthony.fitzroy@justice.gov.uk
   slack_channel: de-probation-airflow-prod
 
 tags:


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Description
This pull request updates the `workflow.yml` configuration for appointment reminders in the production environment, specifically adding new maintainers and notification recipients.

Team membership updates:

* Added `joephillipsjustice` and `AntFMoJ` to the `maintainers` list to ensure they have appropriate access and responsibilities.

Notification updates:

* Added `joseph.phillips@justice.gov.uk` and `anthony.fitzroy@justice.gov.uk` to the notification emails list so they receive workflow notifications.