### PR TITLE
Adding offenders_wap permissions to workflow.yml

### DIFF
--- a/environments/test/sa26-rep/test/workflow.yml
+++ b/environments/test/sa26-rep/test/workflow.yml
@@ -16,6 +16,7 @@ iam:
     - mojap-derived-tables/prod/models/domain_name=prison/database_name=prison_derived/*
     - mojap-derived-tables/prod/models/domain_name=prison/database_name=nomis_ao/*
     - mojap-derived-tables/prod/models/domain_name=prison/database_name=nomis_sensitive/table_name=offenders
+    - mojap-derived-tables/prod/models/domain_name=prison/database_name=nomis_sensitive/table_name=offenders_wap
     - mojap-derived-tables/prod/models/domain_name=prison/database_name=nomis_sensitive/table_name=offender_imprison_statuses
     - mojap-derived-tables/prod/models/domain_name=prison/database_name=nomis_sensitive/table_name=offender_bookings
     - mojap-derived-tables/prod/models/domain_name=prison/database_name=nomis_sensitive/table_name=agency_locations


### PR DESCRIPTION

<!-- markdownlint-disable MD041 -->

## Description

adding db permissions - mojap-derived-tables/prod/models/domain_name=prison/database_name=nomis_sensitive/table_name=offenders_wap 

Fixes #(issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bugfix (non-breaking change which fixes an issue)

## Additional Notes

Add any other context or screenshots about the pull request here.
