### PR TITLE
upping compute for load_hearing_prosecution_counsel table

### DIFF
--- a/environments/production/hmcts/common-platform-load-legacy/workflow.yml
+++ b/environments/production/hmcts/common-platform-load-legacy/workflow.yml
@@ -158,6 +158,7 @@ dag:
     load_hearing_prosecution_counsel:
       env_vars:
         AZ_TABLE: "hearing-prosecution-counsel"
+      compute_profile: general-spot-2vcpu-8gb
     load_hearing_result:
       env_vars:
         AZ_TABLE: "hearing-result"


### PR DESCRIPTION

<!-- markdownlint-disable MD041 -->

## Description

To resolve OOMKilled error, upping compute for failing table.

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)
