### PR TITLE
Update OPG sirius daily tag

### DIFF
--- a/environments/production/opg/sirius-daily/workflow.yml
+++ b/environments/production/opg/sirius-daily/workflow.yml
@@ -1,6 +1,6 @@
 dag:
   repository: moj-analytical-services/airflow-opg-etl
-  tag: v3.7.11-test-11
+  tag: v3.7.11-test-12
   catchup: false
   depends_on_past: false
   is_paused_upon_creation: false
@@ -13,7 +13,6 @@ dag:
     DATABASE: "sirius"
     PIPELINE_NAME: "sirius"
     DATABASE_VERSION: "prod"
-    GITHUB_TAG: "v3.7.11-test-11"
     ATHENA_DB_PREFIX: "opg"
     START_DATE: "2025-06-17"
     AWS_DEFAULT_REGION: "eu-west-1"


### PR DESCRIPTION
## Description

Bump image and remove GITHUB_TAG env var as now provided as a build arg

## Type of change

Please delete options that are not relevant.

- [x] Bugfix (non-breaking change which fixes an issue)
