### PR TITLE
Bump curious 2 version number to v1.2.3

### DIFF
--- a/environments/production/hmpps/prison-curious2/workflow.yml
+++ b/environments/production/hmpps/prison-curious2/workflow.yml
@@ -1,7 +1,7 @@
 dag:
   repository: moj-analytical-services/airflow-curious-2-pipeline
 
-  tag: v1.2.2
+  tag: v1.2.3
 
   schedule: "0 5 * * *"
   catchup: false


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Description

This fix is to display an error if there is a problem with the parquet generation, previously it would silently fail. In the event that the parquet creation doesn't work, we need this to be flagged.

Fixes #(issue)

## Type of change

- [ ] Bugfix (non-breaking change which fixes an issue)

## Additional Notes

Add any other context or screenshots about the pull request here.
