### PR TITLE
Add error for parquet file mismatch

### DIFF
--- a/environments/production/hmpps/prison-curious2/workflow.yml
+++ b/environments/production/hmpps/prison-curious2/workflow.yml
@@ -1,7 +1,7 @@
 dag:
   repository: moj-analytical-services/airflow-curious-2-pipeline
 
-  tag: v1.2.2
+  tag: v1.2.3
 
   schedule: "0 5 * * *"
   catchup: false


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Description

New release to ensure an error is thrown if the number of parquet files don't match the number of csv files.

Fixes #(issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bugfix (non-breaking change which fixes an issue)

## Additional Notes

Add any other context or screenshots about the pull request here.
