### PR TITLE
bump timestamp, add env var

### DIFF
--- a/environments/production/hmcts/common-platform-load-legacy/workflow.yml
+++ b/environments/production/hmcts/common-platform-load-legacy/workflow.yml
@@ -1,6 +1,6 @@
 dag:
   repository: moj-analytical-services/airflow-create-a-pipeline-legacy
-  tag: v1.0.5
+  tag: v1.0.6
   retries: 0
   retry_delay: 150
   start_date: "2025-12-19"
@@ -14,6 +14,7 @@ dag:
     PREPROCESS_DB: "common_platform_dev_sdp_v3_pp"
     CURATED_DB: "common_platform_dev_sdp_v3"
     MAX_SIMULTANEOUS_FILES: "0"
+    DAG_INTERVAL_END: "{{ data_interval_end }}"
 
   tasks:
     load_allocated_listings:


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Description

Bump image tag,
Set new env_var to more accurately set DAG runtime lineage column in final tables.

Fixes #(issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Update to existing role
- [ ] Documentation update

## Additional Notes

Add any other context or screenshots about the pull request here.
