### PR TITLE
bump image version so timestamp function allows DAG interval passing

### DIFF
--- a/environments/production/hmcts/common-platform-load-legacy/workflow.yml
+++ b/environments/production/hmcts/common-platform-load-legacy/workflow.yml
@@ -1,6 +1,6 @@
 dag:
   repository: moj-analytical-services/airflow-create-a-pipeline-legacy
-  tag: v1.0.6
+  tag: v1.0.7
   retries: 0
   retry_delay: 150
   start_date: "2025-12-19"


### PR DESCRIPTION
…without microseconds

<!-- markdownlint-disable MD041 -->

## Description

Bump image version, which fixes `format_airflow_ts ` in our legacy repo allowing for multiple timestamp, inc. with and without microseconds formats, which failed the previous DAG run as the DAG interval is without microseconds on schedule.

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)
