### PR TITLE
fix: test DAG destination path

### DIFF
--- a/environments/test/corp/airflow-file-test/workflow.yml
+++ b/environments/test/corp/airflow-file-test/workflow.yml
@@ -19,7 +19,7 @@ iam:
   glue: true
   s3_read_write:
     - alpha-everyone/affile-testing/installable-load/*
-    - mojap-processed/affile-test/*
+    - mojap-processed/domain__affile_testing/*
 
 notifications:
   slack_channel: dmet-corp-notifications


### PR DESCRIPTION
Fix: add correct S3 destination permissions to test DAG.