### PR TITLE
feat(linking): change pipeline version to "test" and add journey clusters

### DIFF
--- a/environments/test/data-linking/just-link/workflow.yml
+++ b/environments/test/data-linking/just-link/workflow.yml
@@ -17,7 +17,7 @@ dag:
         PIPELINE_VERSION: test
 
     standardised_nodes_mags_hocas:
-      compute_profile: general-spot-32vcpu-128gb
+      compute_profile: general-spot-8vcpu-32gb
       env_vars:
         PIPELINE_STAGE: standardised_nodes
         PIPELINE_DATASET: mags_hocas
@@ -25,7 +25,7 @@ dag:
       dependencies: [source_nodes_mags_hocas]
 
     model_training_mags_hocas:
-      compute_profile: general-spot-64vcpu-256gb
+      compute_profile: general-spot-16vcpu-64gb
       env_vars:
         PIPELINE_STAGE: model_training
         PIPELINE_DATASET: mags_hocas
@@ -33,7 +33,7 @@ dag:
       dependencies: [standardised_nodes_mags_hocas]
 
     edge_generation_mags_hocas:
-      compute_profile: general-spot-64vcpu-256gb
+      compute_profile: general-spot-16vcpu-64gb
       env_vars:
         PIPELINE_STAGE: edge_generation
         PIPELINE_DATASET: mags_hocas
@@ -51,7 +51,7 @@ dag:
         PIPELINE_VERSION: test
 
     standardised_nodes_crown_xhibit:
-      compute_profile: general-spot-4vcpu-16gb
+      compute_profile: general-spot-1vcpu-4gb
       env_vars:
         PIPELINE_STAGE: standardised_nodes
         PIPELINE_DATASET: crown_xhibit
@@ -59,7 +59,7 @@ dag:
       dependencies: [source_nodes_crown_xhibit]
 
     model_training_crown_xhibit:
-      compute_profile: general-spot-8vcpu-32gb
+      compute_profile: general-spot-2vcpu-8gb
       env_vars:
         PIPELINE_STAGE: model_training
         PIPELINE_DATASET: crown_xhibit
@@ -67,7 +67,7 @@ dag:
       dependencies: [standardised_nodes_crown_xhibit]
 
     edge_generation_crown_xhibit:
-      compute_profile: general-spot-8vcpu-32gb
+      compute_profile: general-spot-2vcpu-8gb
       env_vars:
         PIPELINE_STAGE: edge_generation
         PIPELINE_DATASET: crown_xhibit
@@ -85,7 +85,7 @@ dag:
         PIPELINE_VERSION: test
 
     standardised_nodes_common_platform:
-      compute_profile: general-spot-8vcpu-32gb
+      compute_profile: general-spot-2vcpu-8gb
       env_vars:
         PIPELINE_STAGE: standardised_nodes
         PIPELINE_DATASET: common_platform
@@ -93,7 +93,7 @@ dag:
       dependencies: [source_nodes_common_platform]
 
     model_training_common_platform:
-      compute_profile: general-spot-16vcpu-64gb
+      compute_profile: general-spot-4vcpu-16gb
       env_vars:
         PIPELINE_STAGE: model_training
         PIPELINE_DATASET: common_platform
@@ -101,7 +101,7 @@ dag:
       dependencies: [standardised_nodes_common_platform]
 
     edge_generation_common_platform:
-      compute_profile: general-spot-16vcpu-64gb
+      compute_profile: general-spot-4vcpu-16gb
       env_vars:
         PIPELINE_STAGE: edge_generation
         PIPELINE_DATASET: common_platform
@@ -119,7 +119,7 @@ dag:
         PIPELINE_VERSION: test
 
     standardised_nodes_prison_nomis:
-      compute_profile: general-spot-8vcpu-32gb
+      compute_profile: general-spot-2vcpu-8gb
       env_vars:
         PIPELINE_STAGE: standardised_nodes
         PIPELINE_DATASET: prison_nomis
@@ -127,7 +127,7 @@ dag:
       dependencies: [source_nodes_prison_nomis]
 
     model_training_prison_nomis:
-      compute_profile: general-spot-16vcpu-64gb
+      compute_profile: general-spot-4vcpu-16gb
       env_vars:
         PIPELINE_STAGE: model_training
         PIPELINE_DATASET: prison_nomis
@@ -135,7 +135,7 @@ dag:
       dependencies: [standardised_nodes_prison_nomis]
 
     edge_generation_prison_nomis:
-      compute_profile: general-spot-16vcpu-64gb
+      compute_profile: general-spot-4vcpu-16gb
       env_vars:
         PIPELINE_STAGE: edge_generation
         PIPELINE_DATASET: prison_nomis
@@ -153,7 +153,7 @@ dag:
         PIPELINE_VERSION: test
 
     standardised_nodes_prison_oasys:
-      compute_profile: general-spot-8vcpu-32gb
+      compute_profile: general-spot-2vcpu-8gb
       env_vars:
         PIPELINE_STAGE: standardised_nodes
         PIPELINE_DATASET: prison_oasys
@@ -161,7 +161,7 @@ dag:
       dependencies: [source_nodes_prison_oasys]
 
     model_training_prison_oasys:
-      compute_profile: general-spot-16vcpu-64gb
+      compute_profile: general-spot-4vcpu-16gb
       env_vars:
         PIPELINE_STAGE: model_training
         PIPELINE_DATASET: prison_oasys
@@ -169,7 +169,7 @@ dag:
       dependencies: [standardised_nodes_prison_oasys]
 
     edge_generation_prison_oasys:
-      compute_profile: general-spot-16vcpu-64gb
+      compute_profile: general-spot-4vcpu-16gb
       env_vars:
         PIPELINE_STAGE: edge_generation
         PIPELINE_DATASET: prison_oasys
@@ -187,7 +187,7 @@ dag:
         PIPELINE_VERSION: test
 
     standardised_nodes_probation_delius:
-      compute_profile: general-spot-8vcpu-32gb
+      compute_profile: general-spot-2vcpu-8gb
       env_vars:
         PIPELINE_STAGE: standardised_nodes
         PIPELINE_DATASET: probation_delius
@@ -195,7 +195,7 @@ dag:
       dependencies: [source_nodes_probation_delius]
 
     model_training_probation_delius:
-      compute_profile: general-spot-16vcpu-64gb
+      compute_profile: general-spot-4vcpu-16gb
       env_vars:
         PIPELINE_STAGE: model_training
         PIPELINE_DATASET: probation_delius
@@ -203,7 +203,7 @@ dag:
       dependencies: [standardised_nodes_probation_delius]
 
     edge_generation_probation_delius:
-      compute_profile: general-spot-16vcpu-64gb
+      compute_profile: general-spot-4vcpu-16gb
       env_vars:
         PIPELINE_STAGE: edge_generation
         PIPELINE_DATASET: probation_delius
@@ -214,7 +214,7 @@ dag:
     # CJS LINK JOB (~30m)
     # -----------------------
     standardised_nodes_cjs:
-      compute_profile: general-spot-32vcpu-128gb
+      compute_profile: general-spot-8vcpu-32gb
       env_vars:
         PIPELINE_STAGE: standardised_nodes
         PIPELINE_DATASET: cjs
@@ -228,7 +228,7 @@ dag:
         - standardised_nodes_probation_delius
 
     model_training_cjs:
-      compute_profile: general-spot-64vcpu-256gb
+      compute_profile: general-spot-16vcpu-64gb
       env_vars:
         PIPELINE_STAGE: model_training
         PIPELINE_DATASET: cjs
@@ -236,7 +236,7 @@ dag:
       dependencies: [standardised_nodes_cjs]
 
     edge_generation_cjs:
-      compute_profile: general-spot-64vcpu-256gb
+      compute_profile: general-spot-16vcpu-64gb
       env_vars:
         PIPELINE_STAGE: edge_generation
         PIPELINE_DATASET: cjs
@@ -268,7 +268,7 @@ dag:
         PIPELINE_VERSION: test
 
     standardised_nodes_mags_journey:
-      compute_profile: general-spot-32vcpu-128gb
+      compute_profile: general-spot-8vcpu-32gb
       env_vars:
         PIPELINE_STAGE: standardised_nodes
         PIPELINE_DATASET: mags-journey
@@ -276,7 +276,7 @@ dag:
       dependencies: [source_nodes_mags_journey]
 
     standardised_nodes_xhibit_journey:
-      compute_profile: general-spot-4vcpu-16gb
+      compute_profile: general-spot-1vcpu-4gb
       env_vars:
         PIPELINE_STAGE: standardised_nodes
         PIPELINE_DATASET: xhibit-journey
@@ -284,7 +284,7 @@ dag:
       dependencies: [source_nodes_xhibit_journey]
 
     standardised_nodes_mh_cx:
-      compute_profile: general-spot-16vcpu-64gb
+      compute_profile: general-spot-4vcpu-16gb
       env_vars:
         PIPELINE_STAGE: standardised_nodes
         PIPELINE_DATASET: mh-cx
@@ -295,7 +295,7 @@ dag:
         - edge_generation_cjs
 
     model_training_mh_cx:
-      compute_profile: general-spot-16vcpu-64gb
+      compute_profile: general-spot-4vcpu-16gb
       env_vars:
         PIPELINE_STAGE: model_training
         PIPELINE_DATASET: mh-cx
@@ -303,7 +303,7 @@ dag:
       dependencies: [standardised_nodes_mh_cx]
 
     edge_generation_mh_cx:
-      compute_profile: general-spot-16vcpu-64gb
+      compute_profile: general-spot-4vcpu-16gb
       env_vars:
         PIPELINE_STAGE: edge_generation
         PIPELINE_DATASET: mh-cx

--- a/environments/test/data-linking/just-link/workflow.yml
+++ b/environments/test/data-linking/just-link/workflow.yml
@@ -1,6 +1,6 @@
 dag:
   repository: moj-analytical-services/data_linking
-  tag: v5.0.0.dev14
+  tag: v5.0.0.dev15
   retries: 0
   retry_delay: 150
   max_active_runs: 1
@@ -14,14 +14,14 @@ dag:
       env_vars:
         PIPELINE_STAGE: source_nodes
         PIPELINE_DATASET: mags_hocas
-        PIPELINE_VERSION: dev
+        PIPELINE_VERSION: test
 
     standardised_nodes_mags_hocas:
       compute_profile: general-spot-32vcpu-128gb
       env_vars:
         PIPELINE_STAGE: standardised_nodes
         PIPELINE_DATASET: mags_hocas
-        PIPELINE_VERSION: dev
+        PIPELINE_VERSION: test
       dependencies: [source_nodes_mags_hocas]
 
     model_training_mags_hocas:
@@ -29,7 +29,7 @@ dag:
       env_vars:
         PIPELINE_STAGE: model_training
         PIPELINE_DATASET: mags_hocas
-        PIPELINE_VERSION: dev
+        PIPELINE_VERSION: test
       dependencies: [standardised_nodes_mags_hocas]
 
     edge_generation_mags_hocas:
@@ -37,7 +37,7 @@ dag:
       env_vars:
         PIPELINE_STAGE: edge_generation
         PIPELINE_DATASET: mags_hocas
-        PIPELINE_VERSION: dev
+        PIPELINE_VERSION: test
       dependencies: [model_training_mags_hocas]
 
     # -----------------------
@@ -48,14 +48,14 @@ dag:
       env_vars:
         PIPELINE_STAGE: source_nodes
         PIPELINE_DATASET: crown_xhibit
-        PIPELINE_VERSION: dev
+        PIPELINE_VERSION: test
 
     standardised_nodes_crown_xhibit:
       compute_profile: general-spot-4vcpu-16gb
       env_vars:
         PIPELINE_STAGE: standardised_nodes
         PIPELINE_DATASET: crown_xhibit
-        PIPELINE_VERSION: dev
+        PIPELINE_VERSION: test
       dependencies: [source_nodes_crown_xhibit]
 
     model_training_crown_xhibit:
@@ -63,7 +63,7 @@ dag:
       env_vars:
         PIPELINE_STAGE: model_training
         PIPELINE_DATASET: crown_xhibit
-        PIPELINE_VERSION: dev
+        PIPELINE_VERSION: test
       dependencies: [standardised_nodes_crown_xhibit]
 
     edge_generation_crown_xhibit:
@@ -71,7 +71,7 @@ dag:
       env_vars:
         PIPELINE_STAGE: edge_generation
         PIPELINE_DATASET: crown_xhibit
-        PIPELINE_VERSION: dev
+        PIPELINE_VERSION: test
       dependencies: [model_training_crown_xhibit]
 
     # -----------------------
@@ -82,14 +82,14 @@ dag:
       env_vars:
         PIPELINE_STAGE: source_nodes
         PIPELINE_DATASET: common_platform
-        PIPELINE_VERSION: dev
+        PIPELINE_VERSION: test
 
     standardised_nodes_common_platform:
       compute_profile: general-spot-8vcpu-32gb
       env_vars:
         PIPELINE_STAGE: standardised_nodes
         PIPELINE_DATASET: common_platform
-        PIPELINE_VERSION: dev
+        PIPELINE_VERSION: test
       dependencies: [source_nodes_common_platform]
 
     model_training_common_platform:
@@ -97,7 +97,7 @@ dag:
       env_vars:
         PIPELINE_STAGE: model_training
         PIPELINE_DATASET: common_platform
-        PIPELINE_VERSION: dev
+        PIPELINE_VERSION: test
       dependencies: [standardised_nodes_common_platform]
 
     edge_generation_common_platform:
@@ -105,7 +105,7 @@ dag:
       env_vars:
         PIPELINE_STAGE: edge_generation
         PIPELINE_DATASET: common_platform
-        PIPELINE_VERSION: dev
+        PIPELINE_VERSION: test
       dependencies: [model_training_common_platform]
 
     # -----------------------
@@ -116,14 +116,14 @@ dag:
       env_vars:
         PIPELINE_STAGE: source_nodes
         PIPELINE_DATASET: prison_nomis
-        PIPELINE_VERSION: dev
+        PIPELINE_VERSION: test
 
     standardised_nodes_prison_nomis:
       compute_profile: general-spot-8vcpu-32gb
       env_vars:
         PIPELINE_STAGE: standardised_nodes
         PIPELINE_DATASET: prison_nomis
-        PIPELINE_VERSION: dev
+        PIPELINE_VERSION: test
       dependencies: [source_nodes_prison_nomis]
 
     model_training_prison_nomis:
@@ -131,7 +131,7 @@ dag:
       env_vars:
         PIPELINE_STAGE: model_training
         PIPELINE_DATASET: prison_nomis
-        PIPELINE_VERSION: dev
+        PIPELINE_VERSION: test
       dependencies: [standardised_nodes_prison_nomis]
 
     edge_generation_prison_nomis:
@@ -139,7 +139,7 @@ dag:
       env_vars:
         PIPELINE_STAGE: edge_generation
         PIPELINE_DATASET: prison_nomis
-        PIPELINE_VERSION: dev
+        PIPELINE_VERSION: test
       dependencies: [model_training_prison_nomis]
 
     # -----------------------
@@ -150,14 +150,14 @@ dag:
       env_vars:
         PIPELINE_STAGE: source_nodes
         PIPELINE_DATASET: prison_oasys
-        PIPELINE_VERSION: dev
+        PIPELINE_VERSION: test
 
     standardised_nodes_prison_oasys:
       compute_profile: general-spot-8vcpu-32gb
       env_vars:
         PIPELINE_STAGE: standardised_nodes
         PIPELINE_DATASET: prison_oasys
-        PIPELINE_VERSION: dev
+        PIPELINE_VERSION: test
       dependencies: [source_nodes_prison_oasys]
 
     model_training_prison_oasys:
@@ -165,7 +165,7 @@ dag:
       env_vars:
         PIPELINE_STAGE: model_training
         PIPELINE_DATASET: prison_oasys
-        PIPELINE_VERSION: dev
+        PIPELINE_VERSION: test
       dependencies: [standardised_nodes_prison_oasys]
 
     edge_generation_prison_oasys:
@@ -173,7 +173,7 @@ dag:
       env_vars:
         PIPELINE_STAGE: edge_generation
         PIPELINE_DATASET: prison_oasys
-        PIPELINE_VERSION: dev
+        PIPELINE_VERSION: test
       dependencies: [model_training_prison_oasys]
 
     # -----------------------
@@ -184,14 +184,14 @@ dag:
       env_vars:
         PIPELINE_STAGE: source_nodes
         PIPELINE_DATASET: probation_delius
-        PIPELINE_VERSION: dev
+        PIPELINE_VERSION: test
 
     standardised_nodes_probation_delius:
       compute_profile: general-spot-8vcpu-32gb
       env_vars:
         PIPELINE_STAGE: standardised_nodes
         PIPELINE_DATASET: probation_delius
-        PIPELINE_VERSION: dev
+        PIPELINE_VERSION: test
       dependencies: [source_nodes_probation_delius]
 
     model_training_probation_delius:
@@ -199,7 +199,7 @@ dag:
       env_vars:
         PIPELINE_STAGE: model_training
         PIPELINE_DATASET: probation_delius
-        PIPELINE_VERSION: dev
+        PIPELINE_VERSION: test
       dependencies: [standardised_nodes_probation_delius]
 
     edge_generation_probation_delius:
@@ -207,7 +207,7 @@ dag:
       env_vars:
         PIPELINE_STAGE: edge_generation
         PIPELINE_DATASET: probation_delius
-        PIPELINE_VERSION: dev
+        PIPELINE_VERSION: test
       dependencies: [model_training_probation_delius]
 
     # -----------------------
@@ -218,7 +218,7 @@ dag:
       env_vars:
         PIPELINE_STAGE: standardised_nodes
         PIPELINE_DATASET: cjs
-        PIPELINE_VERSION: dev
+        PIPELINE_VERSION: test
       dependencies:
         - standardised_nodes_mags_hocas
         - standardised_nodes_crown_xhibit
@@ -232,7 +232,7 @@ dag:
       env_vars:
         PIPELINE_STAGE: model_training
         PIPELINE_DATASET: cjs
-        PIPELINE_VERSION: dev
+        PIPELINE_VERSION: test
       dependencies: [standardised_nodes_cjs]
 
     edge_generation_cjs:
@@ -240,7 +240,7 @@ dag:
       env_vars:
         PIPELINE_STAGE: edge_generation
         PIPELINE_DATASET: cjs
-        PIPELINE_VERSION: dev
+        PIPELINE_VERSION: test
       dependencies:
         - model_training_cjs
         - edge_generation_mags_hocas
@@ -249,6 +249,66 @@ dag:
         - edge_generation_prison_nomis
         - edge_generation_prison_oasys
         - edge_generation_probation_delius
+
+    # -----------------------
+    # JOURNEY LINK JOB (~?m)
+    # -----------------------
+    source_nodes_mags_journey:
+      compute_profile: general-spot-1vcpu-4gb
+      env_vars:
+        PIPELINE_STAGE: source_nodes
+        PIPELINE_DATASET: mags-journey
+        PIPELINE_VERSION: test
+
+    source_nodes_xhibit_journey:
+      compute_profile: general-spot-1vcpu-4gb
+      env_vars:
+        PIPELINE_STAGE: source_nodes
+        PIPELINE_DATASET: xhibit-journey
+        PIPELINE_VERSION: test
+
+    standardised_nodes_mags_journey:
+      compute_profile: general-spot-32vcpu-128gb
+      env_vars:
+        PIPELINE_STAGE: standardised_nodes
+        PIPELINE_DATASET: mags-journey
+        PIPELINE_VERSION: test
+      dependencies: [source_nodes_mags_journey]
+
+    standardised_nodes_xhibit_journey:
+      compute_profile: general-spot-4vcpu-16gb
+      env_vars:
+        PIPELINE_STAGE: standardised_nodes
+        PIPELINE_DATASET: xhibit-journey
+        PIPELINE_VERSION: test
+      dependencies: [source_nodes_xhibit_journey]
+
+    standardised_nodes_mh_cx:
+      compute_profile: general-spot-16vcpu-64gb
+      env_vars:
+        PIPELINE_STAGE: standardised_nodes
+        PIPELINE_DATASET: mh-cx
+        PIPELINE_VERSION: test
+      dependencies:
+        - standardised_nodes_mags_journey
+        - standardised_nodes_xhibit_journey
+        - edge_generation_cjs
+
+    model_training_mh_cx:
+      compute_profile: general-spot-16vcpu-64gb
+      env_vars:
+        PIPELINE_STAGE: model_training
+        PIPELINE_DATASET: mh-cx
+        PIPELINE_VERSION: test
+      dependencies: [standardised_nodes_mh_cx]
+
+    edge_generation_mh_cx:
+      compute_profile: general-spot-16vcpu-64gb
+      env_vars:
+        PIPELINE_STAGE: edge_generation
+        PIPELINE_DATASET: mh-cx
+        PIPELINE_VERSION: test
+      dependencies: [model_training_mh_cx]
 
 iam:
   athena: write

--- a/environments/test/data-linking/just-link/workflow.yml
+++ b/environments/test/data-linking/just-link/workflow.yml
@@ -1,6 +1,6 @@
 dag:
   repository: moj-analytical-services/data_linking
-  tag: v5.0.0.dev15
+  tag: v5.0.0.dev16
   retries: 0
   retry_delay: 150
   max_active_runs: 1


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Description

Bumps our container version to `v5.0.0.dev15`, allowing us to test our journey cluster stages. I've also changed all versions to use our "test" mode and will promote the existing dev DAG to the development environment.

## Type of change

Please delete options that are not relevant.

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Update to existing role
- [ ] Documentation update
