### PR TITLE
build(linking): bump image version to `v5.0.0.dev18`

### DIFF
--- a/environments/development/data-linking/just-link/workflow.yml
+++ b/environments/development/data-linking/just-link/workflow.yml
@@ -1,6 +1,6 @@
 dag:
   repository: moj-analytical-services/data_linking
-  tag: v5.0.0.dev16
+  tag: v5.0.0.dev18
   retries: 0
   retry_delay: 150
   max_active_runs: 1
@@ -38,6 +38,8 @@ dag:
         PIPELINE_STAGE: edge_generation
         PIPELINE_DATASET: mags_hocas
         PIPELINE_VERSION: dev
+        CPU_USAGE_LOG_ENABLED: true
+        CPU_USAGE_LOG_INTERVAL_SECONDS: 10.0
       dependencies: [model_training_mags_hocas]
 
     # -----------------------
@@ -249,6 +251,66 @@ dag:
         - edge_generation_prison_nomis
         - edge_generation_prison_oasys
         - edge_generation_probation_delius
+
+    # -----------------------
+    # JOURNEY LINK JOB (~?m)
+    # -----------------------
+    source_nodes_mags_journey:
+      compute_profile: general-spot-1vcpu-4gb
+      env_vars:
+        PIPELINE_STAGE: source_nodes
+        PIPELINE_DATASET: mags-journey
+        PIPELINE_VERSION: dev
+
+    source_nodes_xhibit_journey:
+      compute_profile: general-spot-1vcpu-4gb
+      env_vars:
+        PIPELINE_STAGE: source_nodes
+        PIPELINE_DATASET: xhibit-journey
+        PIPELINE_VERSION: dev
+
+    standardised_nodes_mags_journey:
+      compute_profile: general-spot-32vcpu-128gb
+      env_vars:
+        PIPELINE_STAGE: standardised_nodes
+        PIPELINE_DATASET: mags-journey
+        PIPELINE_VERSION: dev
+      dependencies: [source_nodes_mags_journey]
+
+    standardised_nodes_xhibit_journey:
+      compute_profile: general-spot-4vcpu-16gb
+      env_vars:
+        PIPELINE_STAGE: standardised_nodes
+        PIPELINE_DATASET: xhibit-journey
+        PIPELINE_VERSION: dev
+      dependencies: [source_nodes_xhibit_journey]
+
+    standardised_nodes_mh_cx:
+      compute_profile: general-spot-32vcpu-128gb
+      env_vars:
+        PIPELINE_STAGE: standardised_nodes
+        PIPELINE_DATASET: mh-cx
+        PIPELINE_VERSION: dev
+      dependencies:
+        - standardised_nodes_mags_journey
+        - standardised_nodes_xhibit_journey
+        - edge_generation_cjs
+
+    model_training_mh_cx:
+      compute_profile: general-spot-64vcpu-256gb
+      env_vars:
+        PIPELINE_STAGE: model_training
+        PIPELINE_DATASET: mh-cx
+        PIPELINE_VERSION: dev
+      dependencies: [standardised_nodes_mh_cx]
+
+    edge_generation_mh_cx:
+      compute_profile: general-spot-64vcpu-256gb
+      env_vars:
+        PIPELINE_STAGE: edge_generation
+        PIPELINE_DATASET: mh-cx
+        PIPELINE_VERSION: dev
+      dependencies: [model_training_mh_cx]
 
 iam:
   athena: write


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Description

- Bumps our image version to .dev18. Changleog in - https://github.com/moj-analytical-services/data_linking/releases/tag/v5.0.0.dev18
- Adds in the journey cluster logic
- Bumps one of our existing compute profiles (pred + clustering for Mags) as this was OOM'ing

## Type of change

Please delete options that are not relevant.

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Update to existing role
- [ ] Documentation update
