### PR TITLE
compute upped due to OOMKilled error

### DIFF
--- a/environments/production/hmcts-dev/common-platform-load-dev/workflow.yml
+++ b/environments/production/hmcts-dev/common-platform-load-dev/workflow.yml
@@ -157,7 +157,7 @@ dag:
     cp_load_hearing_result:
       env_vars:
         TABLE: "hearing_result"
-        compute_profile: general-spot-32vcpu-128gb
+        compute_profile: general-spot-64vcpu-256gb
     cp_load_hearing_result_amendment:
       env_vars:
         TABLE: "hearing_result_amendment"


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Description

Upping compute for failing table due to `OOMKilled` error.

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)

