### PR TITLE
testing extraction date set to string

### DIFF
--- a/environments/production/hmcts-dev/common-platform-load-dev/workflow.yml
+++ b/environments/production/hmcts-dev/common-platform-load-dev/workflow.yml
@@ -1,6 +1,6 @@
 dag:
   repository: moj-analytical-services/airflow-create-a-pipeline
-  tag: v4.0.24-alpha7ccdee6
+  tag: v4.0.24-alphaea38e17
   retries: 1
   retry_delay: 150
   start_date: "2026-06-01"


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Description

Test extraction date date set to string instead of timestamp to avoid partitioning awkwardness.

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)
