### PR TITLE
feat(just-link): bump compute size for xhibit model training

### DIFF
--- a/environments/production/data-linking/just-link/workflow.yml
+++ b/environments/production/data-linking/just-link/workflow.yml
@@ -59,7 +59,7 @@ dag:
       dependencies: [source_nodes_crown_xhibit]
 
     model_training_crown_xhibit:
-      compute_profile: general-spot-8vcpu-32gb
+      compute_profile: general-spot-16vcpu-64gb
       env_vars:
         PIPELINE_STAGE: model_training
         PIPELINE_DATASET: crown_xhibit


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Description

The Xhibit model training is OOM'ing, so bumping that to a 64gb machine.


## Type of change

Please delete options that are not relevant.

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Update to existing role
- [ ] Documentation update
