### PR TITLE
build(just-link): bump journey compute

### DIFF
--- a/environments/production/data-linking/just-link/workflow.yml
+++ b/environments/production/data-linking/just-link/workflow.yml
@@ -295,7 +295,7 @@ dag:
         - edge_generation_cjs
 
     model_training_mh_cx:
-      compute_profile: general-spot-64vcpu-256gb
+      compute_profile: general-spot-128vcpu-512gb
       env_vars:
         PIPELINE_STAGE: model_training
         PIPELINE_DATASET: mh-cx
@@ -303,7 +303,7 @@ dag:
       dependencies: [standardised_nodes_mh_cx]
 
     edge_generation_mh_cx:
-      compute_profile: general-spot-64vcpu-256gb
+      compute_profile: general-spot-128vcpu-512gb
       env_vars:
         PIPELINE_STAGE: edge_generation
         PIPELINE_DATASET: mh-cx


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Description

We are getting OOM errors when we run model training and predict + cluster, so bumping those. This should hopefully be the max compute we need to get this job running e2e. Stages only run for 20ish mins max, so, whilst the compute is large, it shouldn't be too expensive in the grand scheme of things.

## Type of change

Please delete options that are not relevant.

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Update to existing role
- [ ] Documentation update

## Additional Notes

> [!NOTE]
> At some point in the near future we will upgrade to Splink v5, which supports chunking. Once we get here, we will be able to dramatically reduce the resources used across our training and predict + clustering stages.