### PR TITLE
build(linking): bump compute

### DIFF
--- a/environments/development/data-linking/just-link/workflow.yml
+++ b/environments/development/data-linking/just-link/workflow.yml
@@ -33,7 +33,7 @@ dag:
       dependencies: [standardised_nodes_mags_hocas]
 
     edge_generation_mags_hocas:
-      compute_profile: general-spot-64vcpu-256gb
+      compute_profile: general-spot-128vcpu-512gb
       env_vars:
         PIPELINE_STAGE: edge_generation
         PIPELINE_DATASET: mags_hocas


### PR DESCRIPTION
We are hitting errors with compute limits on Mags due to the scale of the linkage. Bumping one last time before we switch off the culprit

<!-- markdownlint-disable MD041 -->

## Description

We are hitting the following error still, even after some tweaks to manage total memory used by temp DuckDB storage:
```
'message': 'The node was low on resource: ephemeral-storage. '
                       'Threshold quantity: 32111811426, available: '
                       '31024632Ki. Container base was using 166981944Ki, '
                       'request is 0, has larger consumption of '
                       'ephemeral-storage. ',
```

This change is only needed for dev which we run infrequently, so will not feature in our prod build!

## Type of change

Please delete options that are not relevant.

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Update to existing role
- [ ] Documentation update
