### PR TITLE
bump CAP version

### DIFF
--- a/environments/production/hmcts-dev/ccd-load-dev/workflow.yml
+++ b/environments/production/hmcts-dev/ccd-load-dev/workflow.yml
@@ -1,6 +1,6 @@
 dag:
   repository: moj-analytical-services/airflow-create-a-pipeline
-  tag: v4.0.8-alpha.f76c43b
+  tag: v4.0.26-alpha.aea4fea
   retries: 0
   retry_delay: 150
   max_active_runs: 5


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Description

Bump image tag to test fix for silent timestamp casting failures in CCD-probate tables.

Fixes #(issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Update to existing role
- [ ] Documentation update

## Additional Notes

Add any other context or screenshots about the pull request here.
