### PR TITLE
Rename cadet-deployer-dpr-development workflow and bump image tag

### DIFF
--- a/environments/production/hmpps/cadet-deployer-dpr-dev/workflow.yml
+++ b/environments/production/hmpps/cadet-deployer-dpr-dev/workflow.yml
@@ -1,7 +1,7 @@
 ---
 dag:
   repository: ministryofjustice/analytical-platform-airflow-cadet-deployer
-  tag: 1.3.7-rc1
+  tag: 1.3.7-rc2
   compute_profile: general-on-demand-8vcpu-32gb
   schedule: "0 5 * * MON-FRI"
   start_date: "2026-06-18"


### PR DESCRIPTION
This pull request updates the deployment workflow for the HMPPS Cadet Deployer in the production environment. The main change is updating the Docker image tag to a new release candidate version and renaming the workflow file for consistency.

Deployment workflow updates:

* Updated the `dag` configuration in `workflow.yml` to use Docker image tag `1.3.7-rc2` instead of `1.3.7-rc1`.
* Renamed the workflow file from `cadet-deployer-dpr-development/workflow.yml` to `cadet-deployer-dpr-dev/workflow.yml` for improved naming consistency.